### PR TITLE
IE11 fixes with mscrypto-adapter.js

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/mscrypto-adapter"]
+	path = deps/mscrypto-adapter
+	url = https://github.com/vibornoff/mscrypto-adapter.git

--- a/index.html
+++ b/index.html
@@ -35,11 +35,9 @@
             .good{background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAA9ElEQVQ4y2P4//8/AzUxw6Ay0GG/A4vlFu8SEAaxKTIQbNg2r1WWW73+g/EW79UgMeoYhsAzSDYsdFUoM1DjSiyG/bfa6vWIZMOAmlZgMwyI/1hs8wwHK7TY7qEAFDhhsdXrOFCDPC7DgBqW4zEsGhwpUMMeIEnet9nsK0eOYWADQS7Douiu6U43WaQwW0aMYfgMBOE7IO8D6aXEGobLy8j4OymGwRO22SZfRaCihzg0E20YSk6x2eKtBEpHlBiGkfVAhgI1PSbXMKx52WqbpzIWQ4kyDGfhYLnDXQXJUKINw1vagGLfYot3j/lWL9ehW8BiwwA8jA6GeQxGVAAAAABJRU5ErkJggg==);}
             .bad{background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAqklEQVQ4y7WVSxKDIBBE+0DmINnk0J7BpSZZewNXI00BhRXRSdku2gU0r5wPA8wM1Bd4foAhqB+BLq+3RA+9PMOzeT1+3sArbCxBljRPwKMF4x49lX8hIwLTn9WwQ+gOrEDJQgrTGtpAD2BZA1Ie7AzqgFF9Tu6ZcfZ4yPKGYp4oSpUvQjd59lbQBfsB/gndbat7gdKQpUWRto28seVXTz4c5ONLPmDVT8AKvHEh2mU9JE0AAAAASUVORK5CYII=);}
         </style>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/1.0.1/shim.min.js"></script>
+        <script src="deps/mscrypto-adapter/mscrypto-adapter.js"></script>
         <script>
-            window.crypto = window.crypto || window.msCrypto; //for IE11
-            if(window.crypto.webkitSubtle){
-                window.crypto.subtle = window.crypto.webkitSubtle; //for Safari
-            }
             window.TESTBYTES = new Uint8Array([1, 2, 3, 4]);
 
             //shortcuts to insert test results into the table
@@ -1432,7 +1430,7 @@
                         .then(function(key){
                             return window.crypto.subtle.encrypt({
                                 name: "AES-GCM",
-                                iv: window.crypto.getRandomValues(new Uint8Array(4096)),
+                                iv: window.crypto.getRandomValues(new Uint8Array(12)),
                                 additionalData: window.crypto.getRandomValues(new Uint8Array(256)),
                                 tagLength: 128,
                             }, key, TESTBYTES);
@@ -1446,7 +1444,7 @@
                         //decrypt
                         window.crypto.subtle.generateKey(AESGCM, false, ["encrypt", "decrypt"])
                         .then(function(key){
-                            var iv = window.crypto.getRandomValues(new Uint8Array(4096));
+                            var iv = window.crypto.getRandomValues(new Uint8Array(12));
                             var addtl = window.crypto.getRandomValues(new Uint8Array(256));
                             window.crypto.subtle.encrypt({
                                 name: "AES-GCM",


### PR DESCRIPTION
Additionally, AES-GCM _iv_ parameter length is restricted to 12 octets
