### PR TITLE
Improve compatibility reporting by handling synchronous exceptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,21 @@
             }
             window.TESTBYTES = new Uint8Array([1, 2, 3, 4]);
 
+            //Exception-safe wrappers for all window.crypto.subtle methods
+            var window_crypto_subtle = {};
+            var methods = ["encrypt", "decrypt", "sign", "verify", "digest", "generateKey", "deriveKey", "deriveBits", "importKey", "exportKey", "wrapKey", "unwrapKey"];
+            methods.forEach(function(name){
+                if(window.Promise){
+                    window_crypto_subtle[name] = function(){
+                        return window.Promise.resolve(arguments).then(function(args){
+                            return window.crypto.subtle[name].apply(window.crypto.subtle, args);
+                        });
+                    }
+                }else{
+                    window_crypto_subtle[name] = window.crypto.subtle[name].bind(window.crypto.subtle);
+                }
+            });
+
             //shortcuts to insert test results into the table
             function ok(id, cls, msg){
                 return function(){
@@ -69,6 +84,88 @@
                     return e;
                 }
             }
+
+            //Base algorithms for testing
+            window.AESGCM = {
+                name: "AES-GCM",
+                length: 256,
+            };
+            window.ECDSA = {
+                name: "ECDSA",
+                namedCurve: "P-256",
+                hash: {name: "SHA-256"},
+            };
+            window.HMAC = {
+                name: "HMAC",
+                hash: {name: "SHA-256"},
+            };
+            window.ECDH = {
+                name: "ECDH",
+                namedCurve: "P-256",
+            };
+            window.AESKW = {
+                name: "AES-KW",
+                length: 256,
+            };
+            window.RSAOAEP = {
+                name: "RSA-OAEP",
+                //NOTE: THIS IS A SMALL MODULUS FOR TESTING ONLY
+                //DO NOT USE IT FOR REAL! USE AT LEAST 2048
+                modulusLength: 1024,
+                publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+                hash: {name: "SHA-256"},
+            };
+            window.AESCTR = {
+                name: "AES-CTR",
+                length: 256,
+            };
+            window.AESCBC = {
+                name: "AES-CBC",
+                length: 256,
+            };
+            window.AESCFB = {
+                name: "AES-CFB-8",
+                length: 256,
+            };
+            window.RSASSA = {
+                name: "RSASSA-PKCS1-v1_5",
+                //NOTE: THIS IS A SMALL MODULUS FOR TESTING ONLY
+                //DO NOT USE IT FOR REAL! USE AT LEAST 2048
+                modulusLength: 1024,
+                publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+                hash: {name: "SHA-256"},
+            };
+            window.RSAPSS = {
+                name: "RSA-PSS",
+                //NOTE: THIS IS A SMALL MODULUS FOR TESTING ONLY
+                //DO NOT USE IT FOR REAL! USE AT LEAST 2048
+                modulusLength: 1024,
+                publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+                saltLength: 8,
+                hash: {name: "SHA-256"},
+            };
+            window.AESCMAC = {
+                name: "AES-CMAC",
+                length: 256,
+            };
+            window.DH = {
+                name: "DH",
+                //NOTE: THIS IS A SMALL PRIME FOR TESTING ONLY
+                //DO NOT USE IT FOR REAL!
+                //See http://datatracker.ietf.org/doc/rfc3526/ for better primes
+                prime: new Uint8Array([
+                    255,255,255,255,255,255,255,255,201,15,218,162,33,104,194,52,196,198,98,139,
+                    128,220,28,209,41,2,78,8,138,103,204,116,2,11,190,166,59,19,155,34,81,74,8,
+                    121,142,52,4,221,239,149,25,179,205,58,67,27,48,43,10,109,242,95,20,55,79,225,
+                    53,109,109,81,194,69,228,133,181,118,98,94,126,198,244,76,66,233,166,55,237,
+                    107,11,255,92,182,244,6,183,237,238,56,107,251,90,137,159,165,174,159,36,17,
+                    124,75,31,230,73,40,102,81,236,228,91,61,194,0,124,184,161,99,191,5,152,218,
+                    72,54,28,85,211,154,105,22,63,168,253,36,207,95,131,101,93,35,220,163,173,
+                    150,28,98,243,86,32,133,82,187,158,213,41,7,112,150,150,109,103,12,53,78,74,
+                    188,152,4,241,116,108,8,202,35,115,39,255,255,255,255,255,255,255,255
+                ]),
+                generator: new Uint8Array([2]),
+            };
         </script>
     </head>
     <body>
@@ -112,21 +209,14 @@
             ###   AES-GCM   ###
             ###################
             -->
-            <script>
-                //Base algorithm for testing
-                window.AESGCM = {
-                    name: "AES-GCM",
-                    length: 256,
-                }
-            </script>
             <tr id="aes-gcm">
                 <td class="algname"><a href="https://github.com/diafygi/webcrypto-examples/#aes-gcm">AES-GCM</a></td>
                 <td class="encrypt recommended">
                     <script>
                         //encrypt
-                        window.crypto.subtle.generateKey(AESGCM, false, ["encrypt"])
+                        window_crypto_subtle.generateKey(AESGCM, false, ["encrypt"])
                         .then(function(key){
-                            return window.crypto.subtle.encrypt({
+                            return window_crypto_subtle.encrypt({
                                 name: "AES-GCM",
                                 iv: window.crypto.getRandomValues(new Uint8Array(12)),
                                 additionalData: window.crypto.getRandomValues(new Uint8Array(256)),
@@ -140,18 +230,18 @@
                 <td class="decrypt recommended">
                     <script>
                         //decrypt
-                        window.crypto.subtle.generateKey(AESGCM, false, ["encrypt", "decrypt"])
+                        window_crypto_subtle.generateKey(AESGCM, false, ["encrypt", "decrypt"])
                         .then(function(key){
                             var iv = window.crypto.getRandomValues(new Uint8Array(12));
                             var addtl = window.crypto.getRandomValues(new Uint8Array(256));
-                            window.crypto.subtle.encrypt({
+                            window_crypto_subtle.encrypt({
                                 name: "AES-GCM",
                                 iv: iv,
                                 additionalData: addtl,
                                 tagLength: 128,
                             }, key, TESTBYTES)
                             .then(function(encrypted){
-                                return window.crypto.subtle.decrypt({
+                                return window_crypto_subtle.decrypt({
                                     name: "AES-GCM",
                                     iv: iv,
                                     additionalData: addtl,
@@ -172,7 +262,7 @@
                         //generateKey
 
                         //128 bits
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "AES-GCM",
                             length: 128,
                         }, false, ["encrypt", "decrypt"])
@@ -180,7 +270,7 @@
                         .catch(err("aes-gcm", "generateKey", "128 bits"));
 
                         //192 bits
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "AES-GCM",
                             length: 192,
                         }, false, ["encrypt", "decrypt"])
@@ -188,7 +278,7 @@
                         .catch(err("aes-gcm", "generateKey", "192 bits"));
 
                         //256 bits
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "AES-GCM",
                             length: 256,
                         }, false, ["encrypt", "decrypt"])
@@ -203,7 +293,7 @@
                         //importKey
 
                         //jwk
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "oct",
                             k: "KfKY5nueRX7eBrOddn9IerHLv1r-T7qpggaCF3MfSR4",
                             alg: "A256GCM",
@@ -213,7 +303,7 @@
                         .catch(err("aes-gcm", "importKey", "jwk-key"));
 
                         //raw
-                        window.crypto.subtle.importKey("raw", new Uint8Array([
+                        window_crypto_subtle.importKey("raw", new Uint8Array([
                             122,94,39,230,46,23,151,80,131,230,3,101,80,234,143,9,251,
                             152,229,228,89,222,31,135,214,104,55,68,67,59,5,51
                         ]), AESGCM, false, ["encrypt", "decrypt"])
@@ -224,16 +314,16 @@
                 <td class="exportKey recommended">
                     <script>
                         //exportKey
-                        window.crypto.subtle.generateKey(AESGCM, true, ["encrypt", "decrypt"])
+                        window_crypto_subtle.generateKey(AESGCM, true, ["encrypt", "decrypt"])
                         .then(function(key){
 
                             //jwk
-                            window.crypto.subtle.exportKey("jwk", key)
+                            window_crypto_subtle.exportKey("jwk", key)
                             .then(ok("aes-gcm", "exportKey", "jwk-key"))
                             .catch(err("aes-gcm", "exportKey", "jwk-key"));
 
                             //raw
-                            window.crypto.subtle.exportKey("raw", key)
+                            window_crypto_subtle.exportKey("raw", key)
                             .then(ok("aes-gcm", "exportKey", "raw-key"))
                             .catch(err("aes-gcm", "exportKey", "raw-key"));
 
@@ -244,9 +334,9 @@
                 <td class="wrapKey recommended">
                     <script>
                         //RSASSA-PKCS1-v1_5
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSASSA-PKCS1-v1_5",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -254,13 +344,13 @@
                             }, true, ["sign", "verify"])
                             .then(function(rsaKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-GCM", iv: iv}
                                 )
                                 .then(function(){
                                     var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-GCM", iv: iv}
                                     );
@@ -271,9 +361,9 @@
                         .catch(err("aes-gcm", "wrapKey", "RSASSA-PKCS1-v1_5"));
 
                         //RSA-PSS
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSA-PSS",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -282,13 +372,13 @@
                             }, true, ["sign", "verify"])
                             .then(function(rsaKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-GCM", iv: iv}
                                 )
                                 .then(function(){
                                     var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-GCM", iv: iv}
                                     );
@@ -299,9 +389,9 @@
                         .catch(err("aes-gcm", "wrapKey", "RSA-PSS"));
 
                         //RSA-OAEP
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSA-OAEP",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -309,13 +399,13 @@
                             }, true, ["encrypt", "decrypt"])
                             .then(function(rsaKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-GCM", iv: iv}
                                 )
                                 .then(function(){
                                     var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-GCM", iv: iv}
                                     );
@@ -326,22 +416,22 @@
                         .catch(err("aes-gcm", "wrapKey", "RSA-OAEP"));
 
                         //ECDSA
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDSA",
                                 namedCurve: "P-256",
                                 hash: {name: "SHA-256"},
                             }, true, ["sign", "verify"])
                             .then(function(ecdsaKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", ecdsaKey.publicKey, wrappingKey,
                                     {name: "AES-GCM", iv: iv}
                                 )
                                 .then(function(){
                                     var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", ecdsaKey.privateKey, wrappingKey,
                                         {name: "AES-GCM", iv: iv}
                                     );
@@ -352,21 +442,21 @@
                         .catch(err("aes-gcm", "wrapKey", "ECDSA"));
 
                         //ECDH
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDH",
                                 namedCurve: "P-256",
                             }, true, ["deriveBits", "deriveKey"])
                             .then(function(ecdhKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", ecdhKey.publicKey, wrappingKey,
                                     {name: "AES-GCM", iv: iv}
                                 )
                                 .then(function(){
                                     var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", ecdhKey.privateKey, wrappingKey,
                                         {name: "AES-GCM", iv: iv}
                                     );
@@ -377,14 +467,14 @@
                         .catch(err("aes-gcm", "wrapKey", "ECDH"));
 
                         //AES-CTR
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CTR", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-GCM", iv: iv}
                                 );
@@ -394,14 +484,14 @@
                         .catch(err("aes-gcm", "wrapKey", "AES-CTR"));
 
                         //AES-CBC
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CBC", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-GCM", iv: iv}
                                 );
@@ -411,14 +501,14 @@
                         .catch(err("aes-gcm", "wrapKey", "AES-CBC"));
 
                         //AES-GCM
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-GCM", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-GCM", iv: iv}
                                 );
@@ -428,14 +518,14 @@
                         .catch(err("aes-gcm", "wrapKey", "AES-GCM"));
 
                         //HMAC
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "HMAC", hash: {name: "SHA-256"}},
                                 true, ["sign", "verify"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-GCM", iv: iv}
                                 );
@@ -448,9 +538,9 @@
                 <td class="unwrapKey recommended">
                     <script>
                         //RSASSA-PKCS1-v1_5
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSASSA-PKCS1-v1_5",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -458,18 +548,18 @@
                             }, true, ["sign", "verify"])
                             .then(function(rsaKey){
                                 var ivPub = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-GCM", iv: ivPub}
                                 )
                                 .then(function(wrappedPub){
                                     var ivPriv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-GCM", iv: ivPriv}
                                     )
                                     .then(function(wrappedPriv){
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "jwk", wrappedPub, wrappingKey,
                                             {name: "AES-GCM", iv: ivPub},
                                             {
@@ -480,7 +570,7 @@
                                             }, true, ["verify"]
                                         )
                                         .then(function(unwrappedPub){
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "jwk", wrappedPriv, wrappingKey,
                                                 {name: "AES-GCM", iv: ivPriv},
                                                 {
@@ -500,9 +590,9 @@
 
 
                         //RSA-PSS
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSA-PSS",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -511,18 +601,18 @@
                             }, true, ["sign", "verify"])
                             .then(function(rsaKey){
                                 var ivPub = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-GCM", iv: ivPub}
                                 )
                                 .then(function(wrappedPub){
                                     var ivPriv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-GCM", iv: ivPriv}
                                     )
                                     .then(function(wrappedPriv){
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "jwk", wrappedPub, wrappingKey,
                                             {name: "AES-GCM", iv: ivPub},
                                             {
@@ -534,7 +624,7 @@
                                             }, true, ["verify"]
                                         )
                                         .then(function(unwrappedPub){
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "jwk", wrappedPriv, wrappingKey,
                                                 {name: "AES-GCM", iv: ivPriv},
                                                 {
@@ -554,9 +644,9 @@
                         .catch(err("aes-gcm", "unwrapKey", "RSA-PSS"));
 
                         //RSA-OAEP
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSA-OAEP",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -564,18 +654,18 @@
                             }, true, ["encrypt", "decrypt"])
                             .then(function(rsaKey){
                                 var ivPub = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-GCM", iv: ivPub}
                                 )
                                 .then(function(wrappedPub){
                                     var ivPriv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-GCM", iv: ivPriv}
                                     )
                                     .then(function(wrappedPriv){
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "jwk", wrappedPub, wrappingKey,
                                             {name: "AES-GCM", iv: ivPub},
                                             {
@@ -586,7 +676,7 @@
                                             }, true, ["encrypt"]
                                         )
                                         .then(function(unwrappedPub){
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "jwk", wrappedPriv, wrappingKey,
                                                 {name: "AES-GCM", iv: ivPriv},
                                                 {
@@ -605,27 +695,27 @@
                         .catch(err("aes-gcm", "unwrapKey", "RSA-OAEP"));
 
                         //ECDSA
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDSA",
                                 namedCurve: "P-256",
                                 hash: {name: "SHA-256"},
                             }, true, ["sign", "verify"])
                             .then(function(ecdsaKey){
                                 var ivPub = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", ecdsaKey.publicKey, wrappingKey,
                                     {name: "AES-GCM", iv: ivPub}
                                 )
                                 .then(function(wrappedPub){
                                     var ivPriv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", ecdsaKey.privateKey, wrappingKey,
                                         {name: "AES-GCM", iv: ivPriv}
                                     )
                                     .then(function(wrappedPriv){
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "jwk", wrappedPub, wrappingKey,
                                             {name: "AES-GCM", iv: ivPub},
                                             {
@@ -635,7 +725,7 @@
                                             }, true, ["verify"]
                                         )
                                         .then(function(unwrappedPub){
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "jwk", wrappedPriv, wrappingKey,
                                                 {name: "AES-GCM", iv: ivPriv},
                                                 {
@@ -653,27 +743,27 @@
                         .catch(err("aes-gcm", "unwrapKey", "ECDSA"));
 
                         //ECDH
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDH",
                                 namedCurve: "P-256",
                                 hash: {name: "SHA-256"},
                             }, true, ["deriveBits", "deriveKey"])
                             .then(function(ecdhKey){
                                 var ivPub = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", ecdhKey.publicKey, wrappingKey,
                                     {name: "AES-GCM", iv: ivPub}
                                 )
                                 .then(function(wrappedPub){
                                     var ivPriv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", ecdhKey.privateKey, wrappingKey,
                                         {name: "AES-GCM", iv: ivPriv}
                                     )
                                     .then(function(wrappedPriv){
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "jwk", wrappedPub, wrappingKey,
                                             {name: "AES-GCM", iv: ivPub},
                                             {
@@ -683,7 +773,7 @@
                                             }, true, []
                                         )
                                         .then(function(unwrappedPub){
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "jwk", wrappedPriv, wrappingKey,
                                                 {name: "AES-GCM", iv: ivPriv},
                                                 {
@@ -701,19 +791,19 @@
                         .catch(err("aes-gcm", "unwrapKey", "ECDH"));
 
                         //AES-CTR
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CTR", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-GCM", iv: iv}
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "jwk", wrappedKey, wrappingKey,
                                         {name: "AES-GCM", iv: iv},
                                         {name: "AES-CTR", length: 256},
@@ -726,19 +816,19 @@
                         .catch(err("aes-gcm", "unwrapKey", "AES-CTR"));
 
                         //AES-CBC
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CBC", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-GCM", iv: iv}
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "jwk", wrappedKey, wrappingKey,
                                         {name: "AES-GCM", iv: iv},
                                         {name: "AES-CBC", length: 256},
@@ -751,19 +841,19 @@
                         .catch(err("aes-gcm", "unwrapKey", "AES-CBC"));
 
                         //AES-GCM
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-GCM", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-GCM", iv: iv}
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "jwk", wrappedKey, wrappingKey,
                                         {name: "AES-GCM", iv: iv},
                                         {name: "AES-GCM", length: 256},
@@ -776,19 +866,19 @@
                         .catch(err("aes-gcm", "unwrapKey", "AES-GCM"));
 
                         //HMAC
-                        window.crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-GCM", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "HMAC", hash: {name: "SHA-256"}},
                                 true, ["sign", "verify"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-GCM", iv: iv}
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "jwk", wrappedKey, wrappingKey,
                                         {name: "AES-GCM", iv: iv},
                                         {name: "HMAC", hash: {name: "SHA-256"}},
@@ -809,14 +899,6 @@
             ###   ECDSA   ###
             #################
             -->
-            <script>
-                //Base algorithm for testing
-                window.ECDSA = {
-                    name: "ECDSA",
-                    namedCurve: "P-256",
-                    hash: {name: "SHA-256"},
-                }
-            </script>
             <tr id="ecdsa">
                 <td class="algname"><a href="https://github.com/diafygi/webcrypto-examples/#ecdsa">ECDSA</a></td>
                 <td class="encrypt disabled"></td>
@@ -824,9 +906,9 @@
                 <td class="sign recommended">
                     <script>
                         //sign
-                        window.crypto.subtle.generateKey(ECDSA, true, ["sign", "verify"])
+                        window_crypto_subtle.generateKey(ECDSA, true, ["sign", "verify"])
                         .then(function(key){
-                            return window.crypto.subtle.sign(ECDSA, key.privateKey, TESTBYTES);
+                            return window_crypto_subtle.sign(ECDSA, key.privateKey, TESTBYTES);
                         })
                         .then(ok("ecdsa", "sign", "Yes"))
                         .catch(err("ecdsa", "sign", "No"));
@@ -835,11 +917,11 @@
                 <td class="verify recommended">
                     <script>
                         //verify
-                        window.crypto.subtle.generateKey(ECDSA, true, ["sign", "verify"])
+                        window_crypto_subtle.generateKey(ECDSA, true, ["sign", "verify"])
                         .then(function(key){
-                            window.crypto.subtle.sign(ECDSA, key.privateKey, TESTBYTES)
+                            window_crypto_subtle.sign(ECDSA, key.privateKey, TESTBYTES)
                             .then(function(sig){
-                                return window.crypto.subtle.verify(ECDSA, key.publicKey, sig, TESTBYTES);
+                                return window_crypto_subtle.verify(ECDSA, key.publicKey, sig, TESTBYTES);
                             })
                             .then(ok("ecdsa", "verify", "Yes"))
                             .catch(err("ecdsa", "verify", "No"));
@@ -853,7 +935,7 @@
                         //generateKey
 
                         //P-256
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "ECDSA",
                             namedCurve: "P-256",
                         }, false, ["sign", "verify"])
@@ -861,7 +943,7 @@
                         .catch(err("ecdsa", "generateKey", "P-256"));
 
                         //P-384
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "ECDSA",
                             namedCurve: "P-384",
                         }, false, ["sign", "verify"])
@@ -869,7 +951,7 @@
                         .catch(err("ecdsa", "generateKey", "P-384"));
 
                         //P-521
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "ECDSA",
                             namedCurve: "P-521",
                         }, false, ["sign", "verify"])
@@ -884,7 +966,7 @@
                         //importKey
 
                         //jwk
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "EC",
                             crv: "P-256",
                             x: "A5fQnBdBSgBhTjMr1Atpzvh5SKYQ4aQRJ9WTCG5U4m4",
@@ -894,7 +976,7 @@
                         .then(ok("ecdsa", "importKey", "jwk-pub"))
                         .catch(err("ecdsa", "importKey", "jwk-pub"));
 
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "EC",
                             crv: "P-256",
                             x: "A5fQnBdBSgBhTjMr1Atpzvh5SKYQ4aQRJ9WTCG5U4m4",
@@ -906,7 +988,7 @@
                         .catch(err("ecdsa", "importKey", "jwk-priv"));
 
                         //spki
-                        window.crypto.subtle.importKey("spki", new Uint8Array([
+                        window_crypto_subtle.importKey("spki", new Uint8Array([
                             48,89,48,19,6,7,42,134,72,206,61,2,1,6,8,42,134,72,206,61,3,1,7,3,66,0,4,3,151,
                             208,156,23,65,74,0,97,78,51,43,212,11,105,206,248,121,72,166,16,225,164,17,39,
                             213,147,8,110,84,226,110,241,129,125,241,188,179,50,88,199,95,116,249,57,18,216,
@@ -916,7 +998,7 @@
                         .catch(err("ecdsa", "importKey", "spki-pub"));
 
                         //pkcs8
-                        window.crypto.subtle.importKey("pkcs8", new Uint8Array([
+                        window_crypto_subtle.importKey("pkcs8", new Uint8Array([
                             48,129,135,2,1,0,48,19,6,7,42,134,72,206,61,2,1,6,8,42,134,72,206,61,3,1,7,4,109,48,
                             107,2,1,1,4,32,224,59,194,250,28,105,191,201,178,100,179,94,49,143,188,158,174,121,50,
                             23,95,3,138,27,51,89,70,27,120,69,255,42,161,68,3,66,0,4,3,151,208,156,23,65,74,0,97,
@@ -931,25 +1013,25 @@
                 <td class="exportKey recommended">
                     <script>
                         //exportKey
-                        window.crypto.subtle.generateKey(ECDSA, true, ["sign", "verify"])
+                        window_crypto_subtle.generateKey(ECDSA, true, ["sign", "verify"])
                         .then(function(key){
 
                             //jwk
-                            window.crypto.subtle.exportKey("jwk", key.publicKey)
+                            window_crypto_subtle.exportKey("jwk", key.publicKey)
                             .then(ok("ecdsa", "exportKey", "jwk-pub"))
                             .catch(err("ecdsa", "exportKey", "jwk-pub"));
 
-                            window.crypto.subtle.exportKey("jwk", key.privateKey)
+                            window_crypto_subtle.exportKey("jwk", key.privateKey)
                             .then(ok("ecdsa", "exportKey", "jwk-priv"))
                             .catch(err("ecdsa", "exportKey", "jwk-priv"));
 
                             //spki
-                            window.crypto.subtle.exportKey("spki", key.publicKey)
+                            window_crypto_subtle.exportKey("spki", key.publicKey)
                             .then(ok("ecdsa", "exportKey", "spki-pub"))
                             .catch(err("ecdsa", "exportKey", "spki-pub"));
 
                             //pkcs8
-                            window.crypto.subtle.exportKey("pkcs8", key.privateKey)
+                            window_crypto_subtle.exportKey("pkcs8", key.privateKey)
                             .then(ok("ecdsa", "exportKey", "pkcs8-priv"))
                             .catch(err("ecdsa", "exportKey", "pkcs8-priv"));
 
@@ -967,13 +1049,6 @@
             ###   HMAC   ###
             ################
             -->
-            <script>
-                //Base algorithm for testing
-                window.HMAC = {
-                    name: "HMAC",
-                    hash: {name: "SHA-256"},
-                }
-            </script>
             <tr id="hmac">
                 <td class="algname"><a href="https://github.com/diafygi/webcrypto-examples/#hmac">HMAC</a></td>
                 <td class="encrypt disabled"></td>
@@ -981,9 +1056,9 @@
                 <td class="sign recommended">
                     <script>
                         //sign
-                        window.crypto.subtle.generateKey(HMAC, false, ["sign"])
+                        window_crypto_subtle.generateKey(HMAC, false, ["sign"])
                         .then(function(key){
-                            return window.crypto.subtle.sign(HMAC, key, TESTBYTES);
+                            return window_crypto_subtle.sign(HMAC, key, TESTBYTES);
                         })
                         .then(ok("hmac", "sign", "Yes"))
                         .catch(err("hmac", "sign", "No"));
@@ -992,11 +1067,11 @@
                 <td class="verify recommended">
                     <script>
                         //verify
-                        window.crypto.subtle.generateKey(HMAC, false, ["sign", "verify"])
+                        window_crypto_subtle.generateKey(HMAC, false, ["sign", "verify"])
                         .then(function(key){
-                            window.crypto.subtle.sign(HMAC, key, TESTBYTES)
+                            window_crypto_subtle.sign(HMAC, key, TESTBYTES)
                             .then(function(sig){
-                                return window.crypto.subtle.verify(HMAC, key, sig, TESTBYTES);
+                                return window_crypto_subtle.verify(HMAC, key, sig, TESTBYTES);
                             })
                             .then(ok("hmac", "verify", "Yes"))
                             .catch(err("hmac", "verify", "No"));
@@ -1010,7 +1085,7 @@
                         //generateKey
 
                         //sha-1
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "HMAC",
                             hash: {name: "SHA-1"},
                         }, false, ["sign", "verify"])
@@ -1018,7 +1093,7 @@
                         .catch(err("hmac", "generateKey", "SHA-1"));
 
                         //sha-256
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "HMAC",
                             hash: {name: "SHA-256"},
                         }, false, ["sign", "verify"])
@@ -1026,7 +1101,7 @@
                         .catch(err("hmac", "generateKey", "SHA-256"));
 
                         //sha-384
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "HMAC",
                             hash: {name: "SHA-384"},
                         }, false, ["sign", "verify"])
@@ -1034,7 +1109,7 @@
                         .catch(err("hmac", "generateKey", "SHA-384"));
 
                         //sha-512
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "HMAC",
                             hash: {name: "SHA-512"},
                         }, false, ["sign", "verify"])
@@ -1049,7 +1124,7 @@
                         //importKey
 
                         //jwk
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "oct",
                             k: "KfKY5nueRX7eBrOddn9IerHLv1r-T7qpggaCF3MfSR4",
                             alg: "HS256",
@@ -1059,7 +1134,7 @@
                         .catch(err("hmac", "importKey", "jwk-key"));
 
                         //raw
-                        window.crypto.subtle.importKey("raw", new Uint8Array([
+                        window_crypto_subtle.importKey("raw", new Uint8Array([
                             122,94,39,230,46,23,151,80,131,230,3,101,80,234,143,9,251,
                             152,229,228,89,222,31,135,214,104,55,68,67,59,5,51
                         ]), HMAC, false, ["sign", "verify"])
@@ -1070,16 +1145,16 @@
                 <td class="exportKey recommended">
                     <script>
                         //exportKey
-                        window.crypto.subtle.generateKey(HMAC, true, ["sign", "verify"])
+                        window_crypto_subtle.generateKey(HMAC, true, ["sign", "verify"])
                         .then(function(key){
 
                             //jwk
-                            window.crypto.subtle.exportKey("jwk", key)
+                            window_crypto_subtle.exportKey("jwk", key)
                             .then(ok("hmac", "exportKey", "jwk-key"))
                             .catch(err("hmac", "exportKey", "jwk-key"));
 
                             //raw
-                            window.crypto.subtle.exportKey("raw", key)
+                            window_crypto_subtle.exportKey("raw", key)
                             .then(ok("hmac", "exportKey", "raw-key"))
                             .catch(err("hmac", "exportKey", "raw-key"));
 
@@ -1106,7 +1181,7 @@
                 <td class="digest recommended">
                     <script>
                         //digest
-                        window.crypto.subtle.digest({name: "SHA-256"}, TESTBYTES)
+                        window_crypto_subtle.digest({name: "SHA-256"}, TESTBYTES)
                         .then(ok("sha-256", "digest", "Yes"))
                         .catch(err("sha-256", "digest", "No"));
                     </script>
@@ -1135,7 +1210,7 @@
                 <td class="digest recommended">
                     <script>
                         //digest
-                        window.crypto.subtle.digest({name: "SHA-384"}, TESTBYTES)
+                        window_crypto_subtle.digest({name: "SHA-384"}, TESTBYTES)
                         .then(ok("sha-384", "digest", "Yes"))
                         .catch(err("sha-384", "digest", "No"));
                     </script>
@@ -1164,7 +1239,7 @@
                 <td class="digest recommended">
                     <script>
                         //digest
-                        window.crypto.subtle.digest({name: "SHA-512"}, TESTBYTES)
+                        window_crypto_subtle.digest({name: "SHA-512"}, TESTBYTES)
                         .then(ok("sha-512", "digest", "Yes"))
                         .catch(err("sha-512", "digest", "No"));
                     </script>
@@ -1184,13 +1259,6 @@
             ###   ECDH   ###
             ################
             -->
-            <script>
-                //Base algorithm for testing
-                window.ECDH = {
-                    name: "ECDH",
-                    namedCurve: "P-256",
-                }
-            </script>
             <tr id="ecdh">
                 <td class="algname"><a href="https://github.com/diafygi/webcrypto-examples/#ecdh">ECDH</a></td>
                 <td class="encrypt disabled"></td>
@@ -1203,7 +1271,7 @@
                         //generateKey
 
                         //P-256
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "ECDH",
                             namedCurve: "P-256",
                         }, false, ["deriveBits", "deriveKey"])
@@ -1211,7 +1279,7 @@
                         .catch(err("ecdh", "generateKey", "P-256"));
 
                         //P-384
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "ECDH",
                             namedCurve: "P-384",
                         }, false, ["deriveBits", "deriveKey"])
@@ -1219,7 +1287,7 @@
                         .catch(err("ecdh", "generateKey", "P-384"));
 
                         //P-521
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "ECDH",
                             namedCurve: "P-521",
                         }, false, ["deriveBits", "deriveKey"])
@@ -1230,12 +1298,12 @@
                 <td class="deriveKey recommended">
                     <script>
                         //deriveKey
-                        window.crypto.subtle.generateKey(ECDH, false, ["deriveKey"])
+                        window_crypto_subtle.generateKey(ECDH, false, ["deriveKey"])
                         .then(function(key1){
-                            window.crypto.subtle.generateKey(ECDH, false, ["deriveKey"])
+                            window_crypto_subtle.generateKey(ECDH, false, ["deriveKey"])
                             .then(function(key2){
 
-                                window.crypto.subtle.deriveKey({
+                                window_crypto_subtle.deriveKey({
                                     "name": "ECDH",
                                     "namedCurve": "P-256",
                                     "public": key2.publicKey,
@@ -1252,12 +1320,12 @@
                 <td class="deriveBits recommended">
                     <script>
                         //deriveBits
-                        window.crypto.subtle.generateKey(ECDH, false, ["deriveBits"])
+                        window_crypto_subtle.generateKey(ECDH, false, ["deriveBits"])
                         .then(function(key1){
-                            window.crypto.subtle.generateKey(ECDH, false, ["deriveBits"])
+                            window_crypto_subtle.generateKey(ECDH, false, ["deriveBits"])
                             .then(function(key2){
 
-                                window.crypto.subtle.deriveBits({
+                                window_crypto_subtle.deriveBits({
                                     "name": "ECDH",
                                     "namedCurve": "P-256",
                                     "public": key2.publicKey,
@@ -1276,7 +1344,7 @@
                         //importKey
 
                         //jwk
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "EC",
                             crv: "P-256",
                             x: "kgR_PqO07L8sZOBbw6rvv7O_f7clqDeiE3WnMkb5EoI",
@@ -1286,7 +1354,7 @@
                         .then(ok("ecdh", "importKey", "jwk-pub"))
                         .catch(err("ecdh", "importKey", "jwk-pub"));
 
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "EC",
                             crv: "P-256",
                             x: "kgR_PqO07L8sZOBbw6rvv7O_f7clqDeiE3WnMkb5EoI",
@@ -1298,12 +1366,12 @@
                         .catch(err("ecdh", "importKey", "jwk-priv"));
 
                         //raw
-                        window.crypto.subtle.importKey("raw", null, ECDH, false, ["deriveBits", "deriveKey"])
+                        window_crypto_subtle.importKey("raw", null, ECDH, false, ["deriveBits", "deriveKey"])
                         .then(ok("ecdh", "importKey", "raw-pub"))
                         .catch(err("ecdh", "importKey", "raw-pub*"));
 
                         //spki
-                        window.crypto.subtle.importKey("spki", new Uint8Array([
+                        window_crypto_subtle.importKey("spki", new Uint8Array([
                             48,89,48,19,6,7,42,134,72,206,61,2,1,6,8,42,134,72,206,61,3,1,7,3,66,0,4,146,4,127,62,
                             163,180,236,191,44,100,224,91,195,170,239,191,179,191,127,183,37,168,55,162,19,117,167,
                             50,70,249,18,130,118,50,62,94,160,170,75,35,189,24,89,63,65,63,236,181,19,140,8,4,78,
@@ -1313,7 +1381,7 @@
                         .catch(err("ecdh", "importKey", "spki-pub"));
 
                         //pkcs8
-                        window.crypto.subtle.importKey("pkcs8", new Uint8Array([
+                        window_crypto_subtle.importKey("pkcs8", new Uint8Array([
                             48,129,135,2,1,0,48,19,6,7,42,134,72,206,61,2,1,6,8,42,134,72,206,61,3,1,7,4,109,48,107,2,
                             1,1,4,32,229,163,197,74,221,20,21,85,216,26,239,153,43,32,189,21,2,20,56,3,38,158,60,221,35,
                             9,49,8,199,183,34,137,161,68,3,66,0,4,146,4,127,62,163,180,236,191,44,100,224,91,195,170,239,
@@ -1327,30 +1395,30 @@
                 <td class="exportKey recommended">
                     <script>
                         //exportKey
-                        window.crypto.subtle.generateKey(ECDH, true, ["deriveBits", "deriveKey"])
+                        window_crypto_subtle.generateKey(ECDH, true, ["deriveBits", "deriveKey"])
                         .then(function(key){
 
                             //jwk
-                            window.crypto.subtle.exportKey("jwk", key.publicKey)
+                            window_crypto_subtle.exportKey("jwk", key.publicKey)
                             .then(ok("ecdh", "exportKey", "jwk-pub"))
                             .catch(err("ecdh", "exportKey", "jwk-pub"));
 
-                            window.crypto.subtle.exportKey("jwk", key.privateKey)
+                            window_crypto_subtle.exportKey("jwk", key.privateKey)
                             .then(ok("ecdh", "exportKey", "jwk-priv"))
                             .catch(err("ecdh", "exportKey", "jwk-priv"));
 
                             //raw
-                            window.crypto.subtle.exportKey("raw", key.publicKey)
+                            window_crypto_subtle.exportKey("raw", key.publicKey)
                             .then(ok("ecdh", "exportKey", "raw-pub"))
                             .catch(err("ecdh", "exportKey", "raw-pub"));
 
                             //spki
-                            window.crypto.subtle.exportKey("spki", key.publicKey)
+                            window_crypto_subtle.exportKey("spki", key.publicKey)
                             .then(ok("ecdh", "exportKey", "spki-pub"))
                             .catch(err("ecdh", "exportKey", "spki-pub"));
 
                             //pkcs8
-                            window.crypto.subtle.exportKey("pkcs8", key.privateKey)
+                            window_crypto_subtle.exportKey("pkcs8", key.privateKey)
                             .then(ok("ecdh", "exportKey", "pkcs8-priv"))
                             .catch(err("ecdh", "exportKey", "pkcs8-priv"));
 
@@ -1383,7 +1451,7 @@
                             evt.preventDefault();
                             evt.target.style.display = "none";
 
-                            window.crypto.subtle.generateKey({name: "PBKDF2"}, false, ["deriveBits", "deriveKey"])
+                            window_crypto_subtle.generateKey({name: "PBKDF2"}, false, ["deriveBits", "deriveKey"])
                             .then(ok("pbkdf2", "generateKey", "Yes"))
                             .catch(err("pbkdf2", "generateKey", "No"));
                         };
@@ -1393,11 +1461,11 @@
                     <script>
                         //deriveKey
                         var password = window.crypto.getRandomValues(new Uint8Array(16));
-                        window.crypto.subtle.importKey("raw", password, {name: "PBKDF2"}, false, ["deriveBits", "deriveKey"])
+                        window_crypto_subtle.importKey("raw", password, {name: "PBKDF2"}, false, ["deriveBits", "deriveKey"])
                         .then(function(key){
 
                             //sha-1
-                            window.crypto.subtle.deriveKey({
+                            window_crypto_subtle.deriveKey({
                                 name: "PBKDF2",
                                 salt: window.crypto.getRandomValues(new Uint8Array(16)),
                                 iterations: 1000,
@@ -1407,7 +1475,7 @@
                             .catch(err("pbkdf2", "deriveKey", "SHA-1"));
 
                             //sha-256
-                            window.crypto.subtle.deriveKey({
+                            window_crypto_subtle.deriveKey({
                                 name: "PBKDF2",
                                 salt: window.crypto.getRandomValues(new Uint8Array(16)),
                                 iterations: 1000,
@@ -1417,7 +1485,7 @@
                             .catch(err("pbkdf2", "deriveKey", "SHA-256"));
 
                             //sha-384
-                            window.crypto.subtle.deriveKey({
+                            window_crypto_subtle.deriveKey({
                                 name: "PBKDF2",
                                 salt: window.crypto.getRandomValues(new Uint8Array(16)),
                                 iterations: 1000,
@@ -1427,7 +1495,7 @@
                             .catch(err("pbkdf2", "deriveKey", "SHA-384"));
 
                             //sha-512
-                            window.crypto.subtle.deriveKey({
+                            window_crypto_subtle.deriveKey({
                                 name: "PBKDF2",
                                 salt: window.crypto.getRandomValues(new Uint8Array(16)),
                                 iterations: 1000,
@@ -1444,11 +1512,11 @@
                     <script>
                         //deriveBits
                         var password = window.crypto.getRandomValues(new Uint8Array(16));
-                        window.crypto.subtle.importKey("raw", password, {name: "PBKDF2"}, false, ["deriveBits", "deriveKey"])
+                        window_crypto_subtle.importKey("raw", password, {name: "PBKDF2"}, false, ["deriveBits", "deriveKey"])
                         .then(function(key){
 
                             //sha-1
-                            window.crypto.subtle.deriveBits({
+                            window_crypto_subtle.deriveBits({
                                 "name": "PBKDF2",
                                 salt: window.crypto.getRandomValues(new Uint8Array(16)),
                                 iterations: 1000,
@@ -1458,7 +1526,7 @@
                             .catch(err("pbkdf2", "deriveBits", "SHA-1"));
 
                             //sha-256
-                            window.crypto.subtle.deriveBits({
+                            window_crypto_subtle.deriveBits({
                                 "name": "PBKDF2",
                                 salt: window.crypto.getRandomValues(new Uint8Array(16)),
                                 iterations: 1000,
@@ -1468,7 +1536,7 @@
                             .catch(err("pbkdf2", "deriveBits", "SHA-256"));
 
                             //sha-384
-                            window.crypto.subtle.deriveBits({
+                            window_crypto_subtle.deriveBits({
                                 "name": "PBKDF2",
                                 salt: window.crypto.getRandomValues(new Uint8Array(16)),
                                 iterations: 1000,
@@ -1478,7 +1546,7 @@
                             .catch(err("pbkdf2", "deriveBits", "SHA-384"));
 
                             //sha-512
-                            window.crypto.subtle.deriveBits({
+                            window_crypto_subtle.deriveBits({
                                 "name": "PBKDF2",
                                 salt: window.crypto.getRandomValues(new Uint8Array(16)),
                                 iterations: 1000,
@@ -1497,7 +1565,7 @@
 
                         //raw
                         var password = window.crypto.getRandomValues(new Uint8Array(16));
-                        window.crypto.subtle.importKey("raw", password, {name: "PBKDF2"}, false, ["deriveBits", "deriveKey"])
+                        window_crypto_subtle.importKey("raw", password, {name: "PBKDF2"}, false, ["deriveBits", "deriveKey"])
                         .then(ok("pbkdf2", "importKey", "raw"))
                         .catch(err("pbkdf2", "importKey", "raw"));
                     </script>
@@ -1513,13 +1581,6 @@
             ###   AES-KW   ###
             ##################
             -->
-            <script>
-                //Base algorithm for testing
-                window.AESKW = {
-                    name: "AES-KW",
-                    length: 256,
-                };
-            </script>
             <tr id="aes-kw">
                 <td class="algname"><a href="https://github.com/diafygi/webcrypto-examples/#aes-kw">AES-KW</a></td>
                 <td class="encrypt disabled"></td>
@@ -1532,7 +1593,7 @@
                         //generateKey
 
                         //128 bits
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "AES-KW",
                             length: 128,
                         }, false, ["wrapKey", "unwrapKey"])
@@ -1540,7 +1601,7 @@
                         .catch(err("aes-kw", "generateKey", "128 bits"));
 
                         //192 bits
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "AES-KW",
                             length: 192,
                         }, false, ["wrapKey", "unwrapKey"])
@@ -1548,7 +1609,7 @@
                         .catch(err("aes-kw", "generateKey", "192 bits"));
 
                         //256 bits
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "AES-KW",
                             length: 256,
                         }, false, ["wrapKey", "unwrapKey"])
@@ -1563,7 +1624,7 @@
                         //importKey
 
                         //jwk
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "oct",
                             k: "KfKY5nueRX7eBrOddn9IerHLv1r-T7qpggaCF3MfSR4",
                             alg: "A256KW",
@@ -1573,7 +1634,7 @@
                         .catch(err("aes-kw", "importKey", "jwk-key"));
 
                         //raw
-                        window.crypto.subtle.importKey("raw", new Uint8Array([
+                        window_crypto_subtle.importKey("raw", new Uint8Array([
                             122,94,39,230,46,23,151,80,131,230,3,101,80,234,143,9,251,
                             152,229,228,89,222,31,135,214,104,55,68,67,59,5,51
                         ]), AESKW, false, ["wrapKey", "unwrapKey"])
@@ -1584,16 +1645,16 @@
                 <td class="exportKey recommended">
                     <script>
                         //exportKey
-                        window.crypto.subtle.generateKey(AESKW, true, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey(AESKW, true, ["wrapKey", "unwrapKey"])
                         .then(function(key){
 
                             //jwk
-                            window.crypto.subtle.exportKey("jwk", key)
+                            window_crypto_subtle.exportKey("jwk", key)
                             .then(ok("aes-kw", "exportKey", "jwk-key"))
                             .catch(err("aes-kw", "exportKey", "jwk-key"));
 
                             //raw
-                            window.crypto.subtle.exportKey("raw", key)
+                            window_crypto_subtle.exportKey("raw", key)
                             .then(ok("aes-kw", "exportKey", "raw-key"))
                             .catch(err("aes-kw", "exportKey", "raw-key"));
 
@@ -1604,20 +1665,20 @@
                 <td class="wrapKey recommended">
                     <script>
                         //ECDH
-                        window.crypto.subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDH",
                                 namedCurve: "P-256",
                                 hash: {name: "SHA-256"},
                             }, true, ["deriveBits", "deriveKey"])
                             .then(function(ecdhKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", ecdhKey.publicKey, wrappingKey,
                                     {name: "AES-KW"}
                                 )
                                 .then(function(wrappedPub){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "raw", wrappedPub, wrappingKey,
                                         {name: "AES-KW"},
                                         {
@@ -1633,13 +1694,13 @@
                         .catch(err("aes-kw", "wrapKey", "ECDH"));
 
                         //AES-CTR
-                        window.crypto.subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CTR", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey,
                                     {name: "AES-KW"}
                                 );
@@ -1649,13 +1710,13 @@
                         .catch(err("aes-kw", "wrapKey", "AES-CTR"));
 
                         //AES-CBC
-                        window.crypto.subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CBC", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey,
                                     {name: "AES-KW"}
                                 );
@@ -1665,13 +1726,13 @@
                         .catch(err("aes-kw", "wrapKey", "AES-CBC"));
 
                         //AES-GCM
-                        window.crypto.subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-GCM", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey,
                                     {name: "AES-KW"}
                                 );
@@ -1681,13 +1742,13 @@
                         .catch(err("aes-kw", "wrapKey", "AES-GCM"));
 
                         //HMAC
-                        window.crypto.subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "HMAC", hash: {name: "SHA-256"}},
                                 true, ["sign", "verify"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey,
                                     {name: "AES-KW"}
                                 );
@@ -1700,25 +1761,25 @@
                 <td class="unwrapKey recommended">
                     <script>
                         //ECDH
-                        window.crypto.subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDH",
                                 namedCurve: "P-256",
                                 hash: {name: "SHA-256"},
                             }, true, ["deriveBits", "deriveKey"])
                             .then(function(ecdhKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", ecdhKey.publicKey, wrappingKey,
                                     {name: "AES-KW"}
                                 )
                                 .then(function(wrappedPub){
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "raw", ecdhKey.privateKey, wrappingKey,
                                         {name: "AES-KW"}
                                     )
                                     .then(function(wrappedPriv){
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "raw", wrappedPub, wrappingKey,
                                             {name: "AES-KW"},
                                             {
@@ -1728,7 +1789,7 @@
                                             }, true, []
                                         )
                                         .then(function(unwrappedPub){
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "raw", wrappedPriv, wrappingKey,
                                                 {name: "AES-KW"},
                                                 {
@@ -1746,18 +1807,18 @@
                         .catch(err("aes-kw", "unwrapKey", "ECDH"));
 
                         //AES-CTR
-                        window.crypto.subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CTR", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey,
                                     {name: "AES-KW"}
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "raw", wrappedKey, wrappingKey,
                                         {name: "AES-KW"},
                                         {name: "AES-CTR", length: 256},
@@ -1770,18 +1831,18 @@
                         .catch(err("aes-kw", "unwrapKey", "AES-CTR"));
 
                         //AES-CBC
-                        window.crypto.subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CBC", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey,
                                     {name: "AES-KW"}
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "raw", wrappedKey, wrappingKey,
                                         {name: "AES-KW"},
                                         {name: "AES-CBC", length: 256},
@@ -1794,18 +1855,18 @@
                         .catch(err("aes-kw", "unwrapKey", "AES-CBC"));
 
                         //AES-GCM
-                        window.crypto.subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-GCM", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey,
                                     {name: "AES-KW"}
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "raw", wrappedKey, wrappingKey,
                                         {name: "AES-KW"},
                                         {name: "AES-GCM", length: 256},
@@ -1818,18 +1879,18 @@
                         .catch(err("aes-kw", "unwrapKey", "AES-GCM"));
 
                         //HMAC
-                        window.crypto.subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "HMAC", hash: {name: "SHA-256"}},
                                 true, ["sign", "verify"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey,
                                     {name: "AES-KW"}
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "raw", wrappedKey, wrappingKey,
                                         {name: "AES-KW"},
                                         {name: "HMAC", hash: {name: "SHA-256"}},
@@ -1850,25 +1911,14 @@
             ###   RSA-OAEP   ###
             ####################
             -->
-            <script>
-                //Base algorithm for testing
-                window.RSAOAEP = {
-                    name: "RSA-OAEP",
-                    //NOTE: THIS IS A SMALL MODULUS FOR TESTING ONLY
-                    //DO NOT USE IT FOR REAL! USE AT LEAST 2048
-                    modulusLength: 1024,
-                    publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
-                    hash: {name: "SHA-256"},
-                }
-            </script>
             <tr id="rsa-oaep">
                 <td class="algname"><a href="https://github.com/diafygi/webcrypto-examples/#rsa-oaep">RSA-OAEP</a></td>
                 <td class="encrypt unsafe">
                     <script>
                         //encrypt
-                        window.crypto.subtle.generateKey(RSAOAEP, false, ["encrypt", "decrypt"])
+                        window_crypto_subtle.generateKey(RSAOAEP, false, ["encrypt", "decrypt"])
                         .then(function(key){
-                            return window.crypto.subtle.encrypt(RSAOAEP, key.publicKey, TESTBYTES);
+                            return window_crypto_subtle.encrypt(RSAOAEP, key.publicKey, TESTBYTES);
                         })
                         .then(ok("rsa-oaep", "encrypt", "Yes"))
                         .catch(err("rsa-oaep", "encrypt", "No"));
@@ -1877,11 +1927,11 @@
                 <td class="decrypt unsafe">
                     <script>
                         //decrypt
-                        window.crypto.subtle.generateKey(RSAOAEP, false, ["encrypt", "decrypt"])
+                        window_crypto_subtle.generateKey(RSAOAEP, false, ["encrypt", "decrypt"])
                         .then(function(key){
-                            window.crypto.subtle.encrypt(RSAOAEP, key.publicKey, TESTBYTES)
+                            window_crypto_subtle.encrypt(RSAOAEP, key.publicKey, TESTBYTES)
                             .then(function(encrypted){
-                                return window.crypto.subtle.decrypt(RSAOAEP, key.privateKey, encrypted);
+                                return window_crypto_subtle.decrypt(RSAOAEP, key.privateKey, encrypted);
                             })
                             .then(ok("rsa-oaep", "decrypt", "Yes"))
                             .catch(err("rsa-oaep", "decrypt", "No"));
@@ -1901,7 +1951,7 @@
                             evt.target.style.display = "none";
 
                             //1024 bits
-                            window.crypto.subtle.generateKey({
+                            window_crypto_subtle.generateKey({
                                 name: "RSA-OAEP",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -1911,7 +1961,7 @@
                             .catch(err("rsa-oaep", "generateKey", "1024 bits"));
 
                             //2048 bits
-                            window.crypto.subtle.generateKey({
+                            window_crypto_subtle.generateKey({
                                 name: "RSA-OAEP",
                                 modulusLength: 2048,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -1921,7 +1971,7 @@
                             .catch(err("rsa-oaep", "generateKey", "2048 bits"));
 
                             //4096 bits
-                            window.crypto.subtle.generateKey({
+                            window_crypto_subtle.generateKey({
                                 name: "RSA-OAEP",
                                 modulusLength: 4096,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -1940,7 +1990,7 @@
                         //importKey
 
                         //jwk
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "RSA",
                             e: "AQAB",
                             n: "vGO3eU16ag9zRkJ4AK8ZUZrjbtp5xWK0LyFMNT8933evJoHeczexMUzSiXaLrEFSyQZortk81zJH3y41MBO_UFDO_X0crAquNrkjZDrf9Scc5-MdxlWU2Jl7Gc4Z18AC9aNibWVmXhgvHYkEoFdLCFG-2Sq-qIyW4KFkjan05IE",
@@ -1950,7 +2000,7 @@
                         .then(ok("rsa-oaep", "importKey", "jwk-pub"))
                         .catch(err("rsa-oaep", "importKey", "jwk-pub"));
 
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "RSA",
                             e: "AQAB",
                             d: "e-Nm1CB_F7j0p4Cb-T4WmFTh7RbxUthC3j8xnlXwHgWYwaPs9ZRkicgNCfmjEb-qJ-m0ho1Cz4WzlL1CtTKEdr2w0P6L_IQPvWkFYwUm0rpY9doxnOKkzq53dhP5zdc6N8aOLk4cmAcVjw4o_csc85H-0fxzQxsTP0_jhJn7SNE",
@@ -1967,7 +2017,7 @@
                         .catch(err("rsa-oaep", "importKey", "jwk-priv"));
 
                         //spki
-                        window.crypto.subtle.importKey("spki", new Uint8Array([
+                        window_crypto_subtle.importKey("spki", new Uint8Array([
                             48,129,159,48,13,6,9,42,134,72,134,247,13,1,1,1,5,0,3,
                             129,141,0,48,129,137,2,129,129,0,182,93,35,213,252,204,
                             20,103,91,238,105,199,53,114,24,221,114,210,137,173,88,
@@ -1983,7 +2033,7 @@
                         .catch(err("rsa-oaep", "importKey", "spki-pub"));
 
                         //pkcs8
-                        window.crypto.subtle.importKey("pkcs8", new Uint8Array([
+                        window_crypto_subtle.importKey("pkcs8", new Uint8Array([
                             48,130,2,118,2,1,0,48,13,6,9,42,134,72,134,247,13,1,1,1,5,0,4,130,2,96,48,130,2,92,2,1,0,2,129,
                             129,0,217,78,147,218,221,152,10,66,75,127,242,108,182,142,157,44,93,58,176,193,135,103,216,179,
                             69,72,38,115,144,244,12,139,0,245,48,115,204,234,158,193,231,127,178,240,244,203,35,229,203,245,
@@ -2015,25 +2065,25 @@
                 <td class="exportKey unsafe">
                     <script>
                         //exportKey
-                        window.crypto.subtle.generateKey(RSAOAEP, true, ["encrypt", "decrypt"])
+                        window_crypto_subtle.generateKey(RSAOAEP, true, ["encrypt", "decrypt"])
                         .then(function(key){
 
                             //jwk
-                            window.crypto.subtle.exportKey("jwk", key.publicKey)
+                            window_crypto_subtle.exportKey("jwk", key.publicKey)
                             .then(ok("rsa-oaep", "exportKey", "jwk-pub"))
                             .catch(err("rsa-oaep", "exportKey", "jwk-pub"));
 
-                            window.crypto.subtle.exportKey("jwk", key.privateKey)
+                            window_crypto_subtle.exportKey("jwk", key.privateKey)
                             .then(ok("rsa-oaep", "exportKey", "jwk-priv"))
                             .catch(err("rsa-oaep", "exportKey", "jwk-priv"));
 
                             //spki
-                            window.crypto.subtle.exportKey("spki", key.publicKey)
+                            window_crypto_subtle.exportKey("spki", key.publicKey)
                             .then(ok("rsa-oaep", "exportKey", "spki-pub"))
                             .catch(err("rsa-oaep", "exportKey", "spki-pub"));
 
                             //pkcs8
-                            window.crypto.subtle.exportKey("pkcs8", key.privateKey)
+                            window_crypto_subtle.exportKey("pkcs8", key.privateKey)
                             .then(ok("rsa-oaep", "exportKey", "pkcs8-priv"))
                             .catch(err("rsa-oaep", "exportKey", "pkcs8-priv"));
 
@@ -2044,20 +2094,20 @@
                 <td class="wrapKey unsafe">
                     <script>
                         //ECDH
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "RSA-OAEP",
                             modulusLength: 1024,
                             publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
                             hash: {name: "SHA-256"},
                         }, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDH",
                                 namedCurve: "P-256",
                                 hash: {name: "SHA-256"},
                             }, true, ["deriveBits", "deriveKey"])
                             .then(function(ecdhKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", ecdhKey.publicKey, wrappingKey.publicKey,
                                     {
                                         name: "RSA-OAEP",
@@ -2072,18 +2122,18 @@
                         .catch(err("rsa-oaep", "wrapKey", "ECDH"));
 
                         //AES-CTR
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "RSA-OAEP",
                             modulusLength: 1024,
                             publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
                             hash: {name: "SHA-256"},
                         }, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CTR", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey.publicKey,
                                     {
                                         name: "RSA-OAEP",
@@ -2098,18 +2148,18 @@
                         .catch(err("rsa-oaep", "wrapKey", "AES-CTR"));
 
                         //AES-CBC
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "RSA-OAEP",
                             modulusLength: 1024,
                             publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
                             hash: {name: "SHA-256"},
                         }, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CBC", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey.publicKey,
                                     {
                                         name: "RSA-OAEP",
@@ -2124,18 +2174,18 @@
                         .catch(err("rsa-oaep", "wrapKey", "AES-CBC"));
 
                         //AES-GCM
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "RSA-OAEP",
                             modulusLength: 1024,
                             publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
                             hash: {name: "SHA-256"},
                         }, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-GCM", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey.publicKey,
                                     {
                                         name: "RSA-OAEP",
@@ -2150,18 +2200,18 @@
                         .catch(err("rsa-oaep", "wrapKey", "AES-GCM"));
 
                         //HMAC
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "RSA-OAEP",
                             modulusLength: 1024,
                             publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
                             hash: {name: "SHA-1"}, //need shorter hash to accomidate 64 byte HMAC raw export
                         }, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "HMAC", hash: {name: "SHA-256"}},
                                 true, ["sign", "verify"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey.publicKey,
                                     {
                                         name: "RSA-OAEP",
@@ -2179,20 +2229,20 @@
                 <td class="unwrapKey unsafe">
                     <script>
                         //ECDH
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "RSA-OAEP",
                             modulusLength: 1024,
                             publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
                             hash: {name: "SHA-256"},
                         }, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDH",
                                 namedCurve: "P-256",
                                 hash: {name: "SHA-256"},
                             }, true, ["deriveBits", "deriveKey"])
                             .then(function(ecdhKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", ecdhKey.publicKey, wrappingKey.publicKey,
                                     {
                                         name: "RSA-OAEP",
@@ -2202,7 +2252,7 @@
                                     }
                                 )
                                 .then(function(wrappedPub){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "raw", wrappedPub, wrappingKey.privateKey,
                                         {
                                             name: "RSA-OAEP",
@@ -2223,18 +2273,18 @@
                         .catch(err("rsa-oaep", "unwrapKey", "ECDH"));
 
                         //AES-CTR
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "RSA-OAEP",
                             modulusLength: 1024,
                             publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
                             hash: {name: "SHA-256"},
                         }, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CTR", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey.publicKey,
                                     {
                                         name: "RSA-OAEP",
@@ -2244,7 +2294,7 @@
                                     }
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "raw", wrappedKey, wrappingKey.privateKey,
                                         {
                                             name: "RSA-OAEP",
@@ -2262,18 +2312,18 @@
                         .catch(err("rsa-oaep", "unwrapKey", "AES-CTR"));
 
                         //AES-CBC
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "RSA-OAEP",
                             modulusLength: 1024,
                             publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
                             hash: {name: "SHA-256"},
                         }, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CBC", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey.publicKey,
                                     {
                                         name: "RSA-OAEP",
@@ -2283,7 +2333,7 @@
                                     }
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "raw", wrappedKey, wrappingKey.privateKey,
                                         {
                                             name: "RSA-OAEP",
@@ -2301,18 +2351,18 @@
                         .catch(err("rsa-oaep", "unwrapKey", "AES-CBC"));
 
                         //AES-GCM
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "RSA-OAEP",
                             modulusLength: 1024,
                             publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
                             hash: {name: "SHA-256"},
                         }, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-GCM", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey.publicKey,
                                     {
                                         name: "RSA-OAEP",
@@ -2322,7 +2372,7 @@
                                     }
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "raw", wrappedKey, wrappingKey.privateKey,
                                         {
                                             name: "RSA-OAEP",
@@ -2340,18 +2390,18 @@
                         .catch(err("rsa-oaep", "unwrapKey", "AES-GCM"));
 
                         //HMAC
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "RSA-OAEP",
                             modulusLength: 1024,
                             publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
                             hash: {name: "SHA-1"}, //need shorter hash to accomidate 64 byte HMAC raw export
                         }, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "HMAC", hash: {name: "SHA-256"}},
                                 true, ["sign", "verify"])
                             .then(function(aesKey){
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "raw", aesKey, wrappingKey.publicKey,
                                     {
                                         name: "RSA-OAEP",
@@ -2361,7 +2411,7 @@
                                     }
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "raw", wrappedKey, wrappingKey.privateKey,
                                         {
                                             name: "RSA-OAEP",
@@ -2387,21 +2437,14 @@
             ###   AES-CTR   ###
             ###################
             -->
-            <script>
-                //Base algorithm for testing
-                window.AESCTR = {
-                    name: "AES-CTR",
-                    length: 256,
-                }
-            </script>
             <tr id="aes-ctr">
                 <td class="algname"><a href="https://github.com/diafygi/webcrypto-examples/#aes-ctr">AES-CTR</a></td>
                 <td class="encrypt unsafe">
                     <script>
                         //encrypt
-                        window.crypto.subtle.generateKey(AESCTR, false, ["encrypt"])
+                        window_crypto_subtle.generateKey(AESCTR, false, ["encrypt"])
                         .then(function(key){
-                            return window.crypto.subtle.encrypt({
+                            return window_crypto_subtle.encrypt({
                                 name: "AES-CTR",
                                 counter: new Uint8Array(16),
                                 length: 128,
@@ -2414,17 +2457,17 @@
                 <td class="decrypt unsafe">
                     <script>
                         //decrypt
-                        window.crypto.subtle.generateKey(AESCTR, false, ["encrypt", "decrypt"])
+                        window_crypto_subtle.generateKey(AESCTR, false, ["encrypt", "decrypt"])
                         .then(function(key){
                             var counter = new Uint8Array(16);
                             var length = 128;
-                            window.crypto.subtle.encrypt({
+                            window_crypto_subtle.encrypt({
                                 name: "AES-CTR",
                                 counter: counter,
                                 length: length,
                             }, key, TESTBYTES)
                             .then(function(encrypted){
-                                return window.crypto.subtle.decrypt({
+                                return window_crypto_subtle.decrypt({
                                     name: "AES-CTR",
                                     counter: counter,
                                     length: length,
@@ -2444,7 +2487,7 @@
                         //generateKey
 
                         //128 bits
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "AES-CTR",
                             length: 128,
                         }, false, ["encrypt", "decrypt"])
@@ -2452,7 +2495,7 @@
                         .catch(err("aes-ctr", "generateKey", "128 bits"));
 
                         //192 bits
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "AES-CTR",
                             length: 192,
                         }, false, ["encrypt", "decrypt"])
@@ -2460,7 +2503,7 @@
                         .catch(err("aes-ctr", "generateKey", "192 bits"));
 
                         //256 bits
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "AES-CTR",
                             length: 256,
                         }, false, ["encrypt", "decrypt"])
@@ -2475,7 +2518,7 @@
                         //importKey
 
                         //jwk
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "oct",
                             k: "Y0zt37HgOx-BY7SQjYVmrqhPkO44Ii2Jcb9yydUDPfE",
                             alg: "A256CTR",
@@ -2485,7 +2528,7 @@
                         .catch(err("aes-ctr", "importKey", "jwk-key"));
 
                         //raw
-                        window.crypto.subtle.importKey("raw", new Uint8Array([
+                        window_crypto_subtle.importKey("raw", new Uint8Array([
                             122,94,39,230,46,23,151,80,131,230,3,101,80,234,143,9,251,
                             152,229,228,89,222,31,135,214,104,55,68,67,59,5,51
                         ]), AESCTR, false, ["encrypt", "decrypt"])
@@ -2496,16 +2539,16 @@
                 <td class="exportKey unsafe">
                     <script>
                         //exportKey
-                        window.crypto.subtle.generateKey(AESCTR, true, ["encrypt", "decrypt"])
+                        window_crypto_subtle.generateKey(AESCTR, true, ["encrypt", "decrypt"])
                         .then(function(key){
 
                             //jwk
-                            window.crypto.subtle.exportKey("jwk", key)
+                            window_crypto_subtle.exportKey("jwk", key)
                             .then(ok("aes-ctr", "exportKey", "jwk-key"))
                             .catch(err("aes-ctr", "exportKey", "jwk-key"));
 
                             //raw
-                            window.crypto.subtle.exportKey("raw", key)
+                            window_crypto_subtle.exportKey("raw", key)
                             .then(ok("aes-ctr", "exportKey", "raw-key"))
                             .catch(err("aes-ctr", "exportKey", "raw-key"));
 
@@ -2516,9 +2559,9 @@
                 <td class="wrapKey unsafe">
                     <script>
                         //RSASSA-PKCS1-v1_5
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSASSA-PKCS1-v1_5",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -2527,14 +2570,14 @@
                             .then(function(rsaKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 )
                                 .then(function(){
                                     var counter = new Uint8Array(16);
                                     var length = 128;
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-CTR", counter: counter, length: length}
                                     );
@@ -2545,9 +2588,9 @@
                         .catch(err("aes-ctr", "wrapKey", "RSASSA-PKCS1-v1_5"));
 
                         //RSA-PSS
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSA-PSS",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -2557,14 +2600,14 @@
                             .then(function(rsaKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 )
                                 .then(function(){
                                     var counter = new Uint8Array(16);
                                     var length = 128;
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-CTR", counter: counter, length: length}
                                     );
@@ -2575,9 +2618,9 @@
                         .catch(err("aes-ctr", "wrapKey", "RSA-PSS"));
 
                         //RSA-OAEP
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSA-OAEP",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -2586,14 +2629,14 @@
                             .then(function(rsaKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 )
                                 .then(function(){
                                     var counter = new Uint8Array(16);
                                     var length = 128;
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-CTR", counter: counter, length: length}
                                     );
@@ -2604,9 +2647,9 @@
                         .catch(err("aes-ctr", "wrapKey", "RSA-OAEP"));
 
                         //ECDSA
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDSA",
                                 namedCurve: "P-256",
                                 hash: {name: "SHA-256"},
@@ -2614,14 +2657,14 @@
                             .then(function(ecdsaKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", ecdsaKey.publicKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 )
                                 .then(function(){
                                     var counter = new Uint8Array(16);
                                     var length = 128;
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", ecdsaKey.privateKey, wrappingKey,
                                         {name: "AES-CTR", counter: counter, length: length}
                                     );
@@ -2632,23 +2675,23 @@
                         .catch(err("aes-ctr", "wrapKey", "ECDSA"));
 
                         //ECDH
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDH",
                                 namedCurve: "P-256",
                             }, true, ["deriveBits", "deriveKey"])
                             .then(function(ecdhKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", ecdhKey.publicKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 )
                                 .then(function(){
                                     var counter = new Uint8Array(16);
                                     var length = 128;
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", ecdhKey.privateKey, wrappingKey,
                                         {name: "AES-CTR", counter: counter, length: length}
                                     );
@@ -2659,15 +2702,15 @@
                         .catch(err("aes-ctr", "wrapKey", "ECDH"));
 
                         //AES-CTR
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CTR", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 );
@@ -2677,15 +2720,15 @@
                         .catch(err("aes-ctr", "wrapKey", "AES-CTR"));
 
                         //AES-CBC
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CBC", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 );
@@ -2695,15 +2738,15 @@
                         .catch(err("aes-ctr", "wrapKey", "AES-CBC"));
 
                         //AES-GCM
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-GCM", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 );
@@ -2713,15 +2756,15 @@
                         .catch(err("aes-ctr", "wrapKey", "AES-GCM"));
 
                         //HMAC
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "HMAC", hash: {name: "SHA-256"}},
                                 true, ["sign", "verify"])
                             .then(function(aesKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 );
@@ -2734,9 +2777,9 @@
                 <td class="unwrapKey unsafe">
                     <script>
                         //RSASSA-PKCS1-v1_5
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSASSA-PKCS1-v1_5",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -2745,21 +2788,21 @@
                             .then(function(rsaKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 )
                                 .then(function(wrappedPub){
                                     var counter = new Uint8Array(16);
                                     var length = 128;
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-CTR", counter: counter, length: length}
                                     )
                                     .then(function(wrappedPriv){
                                         var counter = new Uint8Array(16);
                                         var length = 128;
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "jwk", wrappedPub, wrappingKey,
                                             {name: "AES-CTR", counter: counter, length: length},
                                             {
@@ -2772,7 +2815,7 @@
                                         .then(function(unwrappedPub){
                                             var counter = new Uint8Array(16);
                                             var length = 128;
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "jwk", wrappedPriv, wrappingKey,
                                                 {name: "AES-CTR", counter: counter, length: length},
                                                 {
@@ -2791,9 +2834,9 @@
                         .catch(err("aes-ctr", "unwrapKey", "RSASSA-PKCS1-v1_5"));
 
                         //RSA-PSS
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSA-PSS",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -2803,21 +2846,21 @@
                             .then(function(rsaKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 )
                                 .then(function(wrappedPub){
                                     var counter = new Uint8Array(16);
                                     var length = 128;
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-CTR", counter: counter, length: length}
                                     )
                                     .then(function(wrappedPriv){
                                         var counter = new Uint8Array(16);
                                         var length = 128;
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "jwk", wrappedPub, wrappingKey,
                                             {name: "AES-CTR", counter: counter, length: length},
                                             {
@@ -2831,7 +2874,7 @@
                                         .then(function(unwrappedPub){
                                             var counter = new Uint8Array(16);
                                             var length = 128;
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "jwk", wrappedPriv, wrappingKey,
                                                 {name: "AES-CTR", counter: counter, length: length},
                                                 {
@@ -2851,9 +2894,9 @@
                         .catch(err("aes-ctr", "unwrapKey", "RSA-PSS"));
 
                         //RSA-OAEP
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSA-OAEP",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -2862,21 +2905,21 @@
                             .then(function(rsaKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 )
                                 .then(function(wrappedPub){
                                     var counter = new Uint8Array(16);
                                     var length = 128;
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-CTR", counter: counter, length: length}
                                     )
                                     .then(function(wrappedPriv){
                                         var counter = new Uint8Array(16);
                                         var length = 128;
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "jwk", wrappedPub, wrappingKey,
                                             {name: "AES-CTR", counter: counter, length: length},
                                             {
@@ -2889,7 +2932,7 @@
                                         .then(function(unwrappedPub){
                                             var counter = new Uint8Array(16);
                                             var length = 128;
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "jwk", wrappedPriv, wrappingKey,
                                                 {name: "AES-CTR", counter: counter, length: length},
                                                 {
@@ -2908,9 +2951,9 @@
                         .catch(err("aes-ctr", "unwrapKey", "RSA-OAEP"));
 
                         //ECDSA
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDSA",
                                 namedCurve: "P-256",
                                 hash: {name: "SHA-256"},
@@ -2918,21 +2961,21 @@
                             .then(function(ecdsaKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", ecdsaKey.publicKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 )
                                 .then(function(wrappedPub){
                                     var counter = new Uint8Array(16);
                                     var length = 128;
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", ecdsaKey.privateKey, wrappingKey,
                                         {name: "AES-CTR", counter: counter, length: length}
                                     )
                                     .then(function(wrappedPriv){
                                         var counter = new Uint8Array(16);
                                         var length = 128;
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "jwk", wrappedPub, wrappingKey,
                                             {name: "AES-CTR", counter: counter, length: length},
                                             {
@@ -2944,7 +2987,7 @@
                                         .then(function(unwrappedPub){
                                             var counter = new Uint8Array(16);
                                             var length = 128;
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "jwk", wrappedPriv, wrappingKey,
                                                 {name: "AES-CTR", counter: counter, length: length},
                                                 {
@@ -2962,9 +3005,9 @@
                         .catch(err("aes-ctr", "unwrapKey", "ECDSA"));
 
                         //ECDH
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDH",
                                 namedCurve: "P-256",
                                 hash: {name: "SHA-256"},
@@ -2972,21 +3015,21 @@
                             .then(function(ecdhKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", ecdhKey.publicKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 )
                                 .then(function(wrappedPub){
                                     var counter = new Uint8Array(16);
                                     var length = 128;
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", ecdhKey.privateKey, wrappingKey,
                                         {name: "AES-CTR", counter: counter, length: length}
                                     )
                                     .then(function(wrappedPriv){
                                         var counter = new Uint8Array(16);
                                         var length = 128;
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "jwk", wrappedPub, wrappingKey,
                                             {name: "AES-CTR", counter: counter, length: length},
                                             {
@@ -2998,7 +3041,7 @@
                                         .then(function(unwrappedPub){
                                             var counter = new Uint8Array(16);
                                             var length = 128;
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "jwk", wrappedPriv, wrappingKey,
                                                 {name: "AES-CTR", counter: counter, length: length},
                                                 {
@@ -3016,22 +3059,22 @@
                         .catch(err("aes-ctr", "unwrapKey", "ECDH"));
 
                         //AES-CTR
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CTR", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 )
                                 .then(function(wrappedKey){
                                     var counter = new Uint8Array(16);
                                     var length = 128;
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "jwk", wrappedKey, wrappingKey,
                                         {name: "AES-CTR", counter: counter, length: length},
                                         {name: "AES-CTR", length: 256},
@@ -3044,22 +3087,22 @@
                         .catch(err("aes-ctr", "unwrapKey", "AES-CTR"));
 
                         //AES-CBC
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CBC", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 )
                                 .then(function(wrappedKey){
                                     var counter = new Uint8Array(16);
                                     var length = 128;
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "jwk", wrappedKey, wrappingKey,
                                         {name: "AES-CTR", counter: counter, length: length},
                                         {name: "AES-CBC", length: 256},
@@ -3072,22 +3115,22 @@
                         .catch(err("aes-ctr", "unwrapKey", "AES-CBC"));
 
                         //AES-GCM
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-GCM", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 )
                                 .then(function(wrappedKey){
                                     var counter = new Uint8Array(16);
                                     var length = 128;
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "jwk", wrappedKey, wrappingKey,
                                         {name: "AES-CTR", counter: counter, length: length},
                                         {name: "AES-GCM", length: 256},
@@ -3100,22 +3143,22 @@
                         .catch(err("aes-ctr", "unwrapKey", "AES-GCM"));
 
                         //HMAC
-                        window.crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CTR", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "HMAC", hash: {name: "SHA-256"}},
                                 true, ["sign", "verify"])
                             .then(function(aesKey){
                                 var counter = new Uint8Array(16);
                                 var length = 128;
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CTR", counter: counter, length: length}
                                 )
                                 .then(function(wrappedKey){
                                     var counter = new Uint8Array(16);
                                     var length = 128;
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "jwk", wrappedKey, wrappingKey,
                                         {name: "AES-CTR", counter: counter, length: length},
                                         {name: "HMAC", hash: {name: "SHA-256"}},
@@ -3136,21 +3179,14 @@
             ###   AES-CBC   ###
             ###################
             -->
-            <script>
-                //Base algorithm for testing
-                window.AESCBC = {
-                    name: "AES-CBC",
-                    length: 256,
-                }
-            </script>
             <tr id="aes-cbc">
                 <td class="algname"><a href="https://github.com/diafygi/webcrypto-examples/#aes-cbc">AES-CBC</a></td>
                 <td class="encrypt unsafe">
                     <script>
                         //encrypt
-                        window.crypto.subtle.generateKey(AESCBC, false, ["encrypt"])
+                        window_crypto_subtle.generateKey(AESCBC, false, ["encrypt"])
                         .then(function(key){
-                            return window.crypto.subtle.encrypt({
+                            return window_crypto_subtle.encrypt({
                                 name: "AES-CBC",
                                 iv: window.crypto.getRandomValues(new Uint8Array(16)),
                             }, key, TESTBYTES);
@@ -3162,15 +3198,15 @@
                 <td class="decrypt unsafe">
                     <script>
                         //decrypt
-                        window.crypto.subtle.generateKey(AESCBC, false, ["encrypt", "decrypt"])
+                        window_crypto_subtle.generateKey(AESCBC, false, ["encrypt", "decrypt"])
                         .then(function(key){
                             var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                            window.crypto.subtle.encrypt({
+                            window_crypto_subtle.encrypt({
                                 name: "AES-CBC",
                                 iv: iv,
                             }, key, TESTBYTES)
                             .then(function(encrypted){
-                                return window.crypto.subtle.decrypt({
+                                return window_crypto_subtle.decrypt({
                                     name: "AES-CBC",
                                     iv: iv,
                                 }, key, encrypted);
@@ -3189,7 +3225,7 @@
                         //generateKey
 
                         //128 bits
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "AES-CBC",
                             length: 128,
                         }, false, ["encrypt", "decrypt"])
@@ -3197,7 +3233,7 @@
                         .catch(err("aes-cbc", "generateKey", "128 bits"));
 
                         //192 bits
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "AES-CBC",
                             length: 192,
                         }, false, ["encrypt", "decrypt"])
@@ -3205,7 +3241,7 @@
                         .catch(err("aes-cbc", "generateKey", "192 bits"));
 
                         //256 bits
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "AES-CBC",
                             length: 256,
                         }, false, ["encrypt", "decrypt"])
@@ -3220,7 +3256,7 @@
                         //importKey
 
                         //jwk
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "oct",
                             k: "KfKY5nueRX7eBrOddn9IerHLv1r-T7qpggaCF3MfSR4",
                             alg: "A256CBC",
@@ -3230,7 +3266,7 @@
                         .catch(err("aes-cbc", "importKey", "jwk-key"));
 
                         //raw
-                        window.crypto.subtle.importKey("raw", new Uint8Array([
+                        window_crypto_subtle.importKey("raw", new Uint8Array([
                             122,94,39,230,46,23,151,80,131,230,3,101,80,234,143,9,251,
                             152,229,228,89,222,31,135,214,104,55,68,67,59,5,51
                         ]), AESCBC, false, ["encrypt", "decrypt"])
@@ -3241,16 +3277,16 @@
                 <td class="exportKey unsafe">
                     <script>
                         //exportKey
-                        window.crypto.subtle.generateKey(AESCBC, true, ["encrypt", "decrypt"])
+                        window_crypto_subtle.generateKey(AESCBC, true, ["encrypt", "decrypt"])
                         .then(function(key){
 
                             //jwk
-                            window.crypto.subtle.exportKey("jwk", key)
+                            window_crypto_subtle.exportKey("jwk", key)
                             .then(ok("aes-cbc", "exportKey", "jwk-key"))
                             .catch(err("aes-cbc", "exportKey", "jwk-key"));
 
                             //raw
-                            window.crypto.subtle.exportKey("raw", key)
+                            window_crypto_subtle.exportKey("raw", key)
                             .then(ok("aes-cbc", "exportKey", "raw-key"))
                             .catch(err("aes-cbc", "exportKey", "raw-key"));
 
@@ -3261,9 +3297,9 @@
                 <td class="wrapKey unsafe">
                     <script>
                         //RSASSA-PKCS1-v1_5
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSASSA-PKCS1-v1_5",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -3271,13 +3307,13 @@
                             }, true, ["sign", "verify"])
                             .then(function(rsaKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-CBC", iv: iv}
                                 )
                                 .then(function(){
                                     var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-CBC", iv: iv}
                                     );
@@ -3288,9 +3324,9 @@
                         .catch(err("aes-cbc", "wrapKey", "RSASSA-PKCS1-v1_5"));
 
                         //RSA-PSS
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSA-PSS",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -3299,13 +3335,13 @@
                             }, true, ["sign", "verify"])
                             .then(function(rsaKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-CBC", iv: iv}
                                 )
                                 .then(function(){
                                     var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-CBC", iv: iv}
                                     );
@@ -3316,9 +3352,9 @@
                         .catch(err("aes-cbc", "wrapKey", "RSA-PSS"));
 
                         //RSA-OAEP
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSA-OAEP",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -3326,13 +3362,13 @@
                             }, true, ["encrypt", "decrypt"])
                             .then(function(rsaKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-CBC", iv: iv}
                                 )
                                 .then(function(){
                                     var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-CBC", iv: iv}
                                     );
@@ -3343,22 +3379,22 @@
                         .catch(err("aes-cbc", "wrapKey", "RSA-OAEP"));
 
                         //ECDSA
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDSA",
                                 namedCurve: "P-256",
                                 hash: {name: "SHA-256"},
                             }, true, ["sign", "verify"])
                             .then(function(ecdsaKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", ecdsaKey.publicKey, wrappingKey,
                                     {name: "AES-CBC", iv: iv}
                                 )
                                 .then(function(){
                                     var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", ecdsaKey.privateKey, wrappingKey,
                                         {name: "AES-CBC", iv: iv}
                                     );
@@ -3369,21 +3405,21 @@
                         .catch(err("aes-cbc", "wrapKey", "ECDSA"));
 
                         //ECDH
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDH",
                                 namedCurve: "P-256",
                             }, true, ["deriveBits", "deriveKey"])
                             .then(function(ecdhKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", ecdhKey.publicKey, wrappingKey,
                                     {name: "AES-CBC", iv: iv}
                                 )
                                 .then(function(){
                                     var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", ecdhKey.privateKey, wrappingKey,
                                         {name: "AES-CBC", iv: iv}
                                     );
@@ -3394,14 +3430,14 @@
                         .catch(err("aes-cbc", "wrapKey", "ECDH"));
 
                         //AES-CTR
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CTR", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CBC", iv: iv}
                                 );
@@ -3411,14 +3447,14 @@
                         .catch(err("aes-cbc", "wrapKey", "AES-CTR"));
 
                         //AES-CBC
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CBC", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CBC", iv: iv}
                                 );
@@ -3428,14 +3464,14 @@
                         .catch(err("aes-cbc", "wrapKey", "AES-CBC"));
 
                         //AES-GCM
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-GCM", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CBC", iv: iv}
                                 );
@@ -3445,14 +3481,14 @@
                         .catch(err("aes-cbc", "wrapKey", "AES-GCM"));
 
                         //HMAC
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "HMAC", hash: {name: "SHA-256"}},
                                 true, ["sign", "verify"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CBC", iv: iv}
                                 );
@@ -3465,9 +3501,9 @@
                 <td class="unwrapKey unsafe">
                     <script>
                         //RSASSA-PKCS1-v1_5
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSASSA-PKCS1-v1_5",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -3475,18 +3511,18 @@
                             }, true, ["sign", "verify"])
                             .then(function(rsaKey){
                                 var ivPub = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-CBC", iv: ivPub}
                                 )
                                 .then(function(wrappedPub){
                                     var ivPriv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-CBC", iv: ivPriv}
                                     )
                                     .then(function(wrappedPriv){
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "jwk", wrappedPub, wrappingKey,
                                             {name: "AES-CBC", iv: ivPub},
                                             {
@@ -3497,7 +3533,7 @@
                                             }, true, ["verify"]
                                         )
                                         .then(function(unwrappedPub){
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "jwk", wrappedPriv, wrappingKey,
                                                 {name: "AES-CBC", iv: ivPriv},
                                                 {
@@ -3516,9 +3552,9 @@
                         .catch(err("aes-cbc", "unwrapKey", "RSASSA-PKCS1-v1_5"));
 
                         //RSA-PSS
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSA-PSS",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -3527,18 +3563,18 @@
                             }, true, ["sign", "verify"])
                             .then(function(rsaKey){
                                 var ivPub = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-CBC", iv: ivPub}
                                 )
                                 .then(function(wrappedPub){
                                     var ivPriv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-CBC", iv: ivPriv}
                                     )
                                     .then(function(wrappedPriv){
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "jwk", wrappedPub, wrappingKey,
                                             {name: "AES-CBC", iv: ivPub},
                                             {
@@ -3550,7 +3586,7 @@
                                             }, true, ["verify"]
                                         )
                                         .then(function(unwrappedPub){
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "jwk", wrappedPriv, wrappingKey,
                                                 {name: "AES-CBC", iv: ivPriv},
                                                 {
@@ -3570,9 +3606,9 @@
                         .catch(err("aes-cbc", "unwrapKey", "RSA-PSS"));
 
                         //RSA-OAEP
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "RSA-OAEP",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -3580,18 +3616,18 @@
                             }, true, ["encrypt", "decrypt"])
                             .then(function(rsaKey){
                                 var ivPub = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", rsaKey.publicKey, wrappingKey,
                                     {name: "AES-CBC", iv: ivPub}
                                 )
                                 .then(function(wrappedPub){
                                     var ivPriv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", rsaKey.privateKey, wrappingKey,
                                         {name: "AES-CBC", iv: ivPriv}
                                     )
                                     .then(function(wrappedPriv){
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "jwk", wrappedPub, wrappingKey,
                                             {name: "AES-CBC", iv: ivPub},
                                             {
@@ -3602,7 +3638,7 @@
                                             }, true, ["encrypt"]
                                         )
                                         .then(function(unwrappedPub){
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "jwk", wrappedPriv, wrappingKey,
                                                 {name: "AES-CBC", iv: ivPriv},
                                                 {
@@ -3621,27 +3657,27 @@
                         .catch(err("aes-cbc", "unwrapKey", "RSA-OAEP"));
 
                         //ECDSA
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDSA",
                                 namedCurve: "P-256",
                                 hash: {name: "SHA-256"},
                             }, true, ["sign", "verify"])
                             .then(function(ecdsaKey){
                                 var ivPub = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", ecdsaKey.publicKey, wrappingKey,
                                     {name: "AES-CBC", iv: ivPub}
                                 )
                                 .then(function(wrappedPub){
                                     var ivPriv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", ecdsaKey.privateKey, wrappingKey,
                                         {name: "AES-CBC", iv: ivPriv}
                                     )
                                     .then(function(wrappedPriv){
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "jwk", wrappedPub, wrappingKey,
                                             {name: "AES-CBC", iv: ivPub},
                                             {
@@ -3651,7 +3687,7 @@
                                             }, true, ["verify"]
                                         )
                                         .then(function(unwrappedPub){
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "jwk", wrappedPriv, wrappingKey,
                                                 {name: "AES-CBC", iv: ivPriv},
                                                 {
@@ -3669,27 +3705,27 @@
                         .catch(err("aes-cbc", "unwrapKey", "ECDSA"));
 
                         //ECDH
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey({
+                            return window_crypto_subtle.generateKey({
                                 name: "ECDH",
                                 namedCurve: "P-256",
                                 hash: {name: "SHA-256"},
                             }, true, ["deriveBits", "deriveKey"])
                             .then(function(ecdhKey){
                                 var ivPub = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", ecdhKey.publicKey, wrappingKey,
                                     {name: "AES-CBC", iv: ivPub}
                                 )
                                 .then(function(wrappedPub){
                                     var ivPriv = window.crypto.getRandomValues(new Uint8Array(16));
-                                    return window.crypto.subtle.wrapKey(
+                                    return window_crypto_subtle.wrapKey(
                                         "jwk", ecdhKey.privateKey, wrappingKey,
                                         {name: "AES-CBC", iv: ivPriv}
                                     )
                                     .then(function(wrappedPriv){
-                                        return window.crypto.subtle.unwrapKey(
+                                        return window_crypto_subtle.unwrapKey(
                                             "jwk", wrappedPub, wrappingKey,
                                             {name: "AES-CBC", iv: ivPub},
                                             {
@@ -3699,7 +3735,7 @@
                                             }, true, []
                                         )
                                         .then(function(unwrappedPub){
-                                            return window.crypto.subtle.unwrapKey(
+                                            return window_crypto_subtle.unwrapKey(
                                                 "jwk", wrappedPriv, wrappingKey,
                                                 {name: "AES-CBC", iv: ivPriv},
                                                 {
@@ -3717,19 +3753,19 @@
                         .catch(err("aes-cbc", "unwrapKey", "ECDH"));
 
                         //AES-CTR
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CTR", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CBC", iv: iv}
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "jwk", wrappedKey, wrappingKey,
                                         {name: "AES-CBC", iv: iv},
                                         {name: "AES-CTR", length: 256},
@@ -3742,19 +3778,19 @@
                         .catch(err("aes-cbc", "unwrapKey", "AES-CTR"));
 
                         //AES-CBC
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-CBC", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CBC", iv: iv}
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "jwk", wrappedKey, wrappingKey,
                                         {name: "AES-CBC", iv: iv},
                                         {name: "AES-CBC", length: 256},
@@ -3767,19 +3803,19 @@
                         .catch(err("aes-cbc", "unwrapKey", "AES-CBC"));
 
                         //AES-GCM
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "AES-GCM", length: 256},
                                 true, ["encrypt", "decrypt"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CBC", iv: iv}
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "jwk", wrappedKey, wrappingKey,
                                         {name: "AES-CBC", iv: iv},
                                         {name: "AES-GCM", length: 256},
@@ -3792,19 +3828,19 @@
                         .catch(err("aes-cbc", "unwrapKey", "AES-GCM"));
 
                         //HMAC
-                        window.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey({name: "AES-CBC", length: 256}, false, ["wrapKey", "unwrapKey"])
                         .then(function(wrappingKey){
-                            return window.crypto.subtle.generateKey(
+                            return window_crypto_subtle.generateKey(
                                 {name: "HMAC", hash: {name: "SHA-256"}},
                                 true, ["sign", "verify"])
                             .then(function(aesKey){
                                 var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                                return window.crypto.subtle.wrapKey(
+                                return window_crypto_subtle.wrapKey(
                                     "jwk", aesKey, wrappingKey,
                                     {name: "AES-CBC", iv: iv}
                                 )
                                 .then(function(wrappedKey){
-                                    return window.crypto.subtle.unwrapKey(
+                                    return window_crypto_subtle.unwrapKey(
                                         "jwk", wrappedKey, wrappingKey,
                                         {name: "AES-CBC", iv: iv},
                                         {name: "HMAC", hash: {name: "SHA-256"}},
@@ -3825,21 +3861,14 @@
             ###   AES-CFB   ###
             ###################
             -->
-            <script>
-                //Base algorithm for testing
-                window.AESCFB = {
-                    name: "AES-CFB-8",
-                    length: 256,
-                }
-            </script>
             <tr id="aes-cfb">
                 <td class="algname"><a href="https://github.com/diafygi/webcrypto-examples/#aes-cfb">AES-CFB</a></td>
                 <td class="encrypt unsafe">
                     <script>
                         //encrypt
-                        window.crypto.subtle.generateKey(AESCFB, false, ["encrypt"])
+                        window_crypto_subtle.generateKey(AESCFB, false, ["encrypt"])
                         .then(function(key){
-                            return window.crypto.subtle.encrypt({
+                            return window_crypto_subtle.encrypt({
                                 name: "AES-CFB-8",
                                 iv: window.crypto.getRandomValues(new Uint8Array(16)),
                             }, key, TESTBYTES);
@@ -3851,15 +3880,15 @@
                 <td class="decrypt unsafe">
                     <script>
                         //decrypt
-                        window.crypto.subtle.generateKey(AESCFB, false, ["encrypt", "decrypt"])
+                        window_crypto_subtle.generateKey(AESCFB, false, ["encrypt", "decrypt"])
                         .then(function(key){
                             var iv = window.crypto.getRandomValues(new Uint8Array(16));
-                            window.crypto.subtle.encrypt({
+                            window_crypto_subtle.encrypt({
                                 name: "AES-CFB-8",
                                 iv: iv,
                             }, key, TESTBYTES)
                             .then(function(encrypted){
-                                return window.crypto.subtle.decrypt({
+                                return window_crypto_subtle.decrypt({
                                     name: "AES-CFB-8",
                                     iv: iv,
                                 }, key, encrypted);
@@ -3878,7 +3907,7 @@
                         //generateKey
 
                         //128 bits
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "AES-CFB-8",
                             length: 128,
                         }, false, ["encrypt", "decrypt"])
@@ -3886,7 +3915,7 @@
                         .catch(err("aes-cfb", "generateKey", "128 bits"));
 
                         //192 bits
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "AES-CFB-8",
                             length: 192,
                         }, false, ["encrypt", "decrypt"])
@@ -3894,7 +3923,7 @@
                         .catch(err("aes-cfb", "generateKey", "192 bits"));
 
                         //256 bits
-                        window.crypto.subtle.generateKey({
+                        window_crypto_subtle.generateKey({
                             name: "AES-CFB-8",
                             length: 256,
                         }, false, ["encrypt", "decrypt"])
@@ -3909,7 +3938,7 @@
                         //importKey
 
                         //jwk
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "oct",
                             k: "Y0zt37HgOx-BY7SQjYVmrqhPkO44Ii2Jcb9yydUDPfE",
                             alg: "A256CFB8",
@@ -3919,7 +3948,7 @@
                         .catch(err("aes-cfb", "importKey", "jwk-key"));
 
                         //raw
-                        window.crypto.subtle.importKey("raw", new Uint8Array([
+                        window_crypto_subtle.importKey("raw", new Uint8Array([
                             122,94,39,230,46,23,151,80,131,230,3,101,80,234,143,9,251,
                             152,229,228,89,222,31,135,214,104,55,68,67,59,5,51
                         ]), AESCFB, false, ["encrypt", "decrypt"])
@@ -3930,16 +3959,16 @@
                 <td class="exportKey unsafe">
                     <script>
                         //exportKey
-                        window.crypto.subtle.generateKey(AESCFB, true, ["encrypt", "decrypt"])
+                        window_crypto_subtle.generateKey(AESCFB, true, ["encrypt", "decrypt"])
                         .then(function(key){
 
                             //jwk
-                            window.crypto.subtle.exportKey("jwk", key)
+                            window_crypto_subtle.exportKey("jwk", key)
                             .then(ok("aes-cfb", "exportKey", "jwk-key"))
                             .catch(err("aes-cfb", "exportKey", "jwk-key"));
 
                             //raw
-                            window.crypto.subtle.exportKey("raw", key)
+                            window_crypto_subtle.exportKey("raw", key)
                             .then(ok("aes-cfb", "exportKey", "raw-key"))
                             .catch(err("aes-cfb", "exportKey", "raw-key"));
 
@@ -3949,14 +3978,14 @@
                 </td>
                 <td class="wrapKey unsafe">
                     <script>
-                        window.crypto.subtle.generateKey(AESCFB, true, ["wrapKey"])
+                        window_crypto_subtle.generateKey(AESCFB, true, ["wrapKey"])
                         .then(ok("aes-cfb", "wrapKey", "TODO"))
                         .catch(err("aes-cfb", "wrapKey", "N/A"));
                     </script>
                 </td>
                 <td class="unwrapKey unsafe">
                     <script>
-                        window.crypto.subtle.generateKey(AESCFB, true, ["wrapKey", "unwrapKey"])
+                        window_crypto_subtle.generateKey(AESCFB, true, ["wrapKey", "unwrapKey"])
                         .then(ok("aes-cfb", "unwrapKey", "TODO"))
                         .catch(err("aes-cfb", "unwrapKey", "N/A"));
                     </script>
@@ -3969,17 +3998,6 @@
             ###   RSASSA-PKCS1-v1_5   ###
             #############################
             -->
-            <script>
-                //Base algorithm for testing
-                window.RSASSA = {
-                    name: "RSASSA-PKCS1-v1_5",
-                    //NOTE: THIS IS A SMALL MODULUS FOR TESTING ONLY
-                    //DO NOT USE IT FOR REAL! USE AT LEAST 2048
-                    modulusLength: 1024,
-                    publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
-                    hash: {name: "SHA-256"},
-                }
-            </script>
             <tr id="rsassa-pkcs1">
                 <td class="algname"><a href="https://github.com/diafygi/webcrypto-examples/#rsassa-pkcs1-v1_5">RSASSA-PKCS1-v1_5</a></td>
                 <td class="encrypt disabled"></td>
@@ -3987,9 +4005,9 @@
                 <td class="sign unsafe">
                     <script>
                         //sign
-                        window.crypto.subtle.generateKey(RSASSA, false, ["sign"])
+                        window_crypto_subtle.generateKey(RSASSA, false, ["sign"])
                         .then(function(key){
-                            return window.crypto.subtle.sign(RSASSA, key.privateKey, TESTBYTES);
+                            return window_crypto_subtle.sign(RSASSA, key.privateKey, TESTBYTES);
                         })
                         .then(ok("rsassa-pkcs1", "sign", "Yes"))
                         .catch(err("rsassa-pkcs1", "sign", "No"));
@@ -3998,11 +4016,11 @@
                 <td class="verify unsafe">
                     <script>
                         //verify
-                        window.crypto.subtle.generateKey(RSASSA, false, ["sign", "verify"])
+                        window_crypto_subtle.generateKey(RSASSA, false, ["sign", "verify"])
                         .then(function(key){
-                            window.crypto.subtle.sign(RSASSA, key.privateKey, TESTBYTES)
+                            window_crypto_subtle.sign(RSASSA, key.privateKey, TESTBYTES)
                             .then(function(sig){
-                                return window.crypto.subtle.verify(RSASSA, key.publicKey, sig, TESTBYTES);
+                                return window_crypto_subtle.verify(RSASSA, key.publicKey, sig, TESTBYTES);
                             })
                             .then(ok("rsassa-pkcs1", "verify", "Yes"))
                             .catch(err("rsassa-pkcs1", "verify", "No"));
@@ -4020,7 +4038,7 @@
                             evt.target.style.display = "none";
 
                             //1024 bits
-                            window.crypto.subtle.generateKey({
+                            window_crypto_subtle.generateKey({
                                 name: "RSASSA-PKCS1-v1_5",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -4030,7 +4048,7 @@
                             .catch(err("rsassa-pkcs1", "generateKey", "1024 bits"));
 
                             //2048 bits
-                            window.crypto.subtle.generateKey({
+                            window_crypto_subtle.generateKey({
                                 name: "RSASSA-PKCS1-v1_5",
                                 modulusLength: 2048,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -4040,7 +4058,7 @@
                             .catch(err("rsassa-pkcs1", "generateKey", "2048 bits"));
 
                             //4096 bits
-                            window.crypto.subtle.generateKey({
+                            window_crypto_subtle.generateKey({
                                 name: "RSASSA-PKCS1-v1_5",
                                 modulusLength: 4096,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -4059,7 +4077,7 @@
                         //importKey
 
                         //jwk
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "RSA",
                             e: "AQAB",
                             n: "vGO3eU16ag9zRkJ4AK8ZUZrjbtp5xWK0LyFMNT8933evJoHeczexMUzSiXaLrEFSyQZortk81zJH3y41MBO_UFDO_X0crAquNrkjZDrf9Scc5-MdxlWU2Jl7Gc4Z18AC9aNibWVmXhgvHYkEoFdLCFG-2Sq-qIyW4KFkjan05IE",
@@ -4069,7 +4087,7 @@
                         .then(ok("rsassa-pkcs1", "importKey", "jwk-pub"))
                         .catch(err("rsassa-pkcs1", "importKey", "jwk-pub"));
 
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "RSA",
                             e: "AQAB",
                             d: "n_dIVw9MD_04lANi5KnKJPoRfxKy7cGHYLG0hU5DGpsFNfx2yH0Uz9j8uU7ZARai1iHECBxcxhpi3wbckQtjmbkCUKvs4G0gKLT9UuNHcCbh0WfvadfPPec52n4z6s4zwisbgWCNbT2L-SyHt1yuFmLAYXkg0swk3y5Bt_ilA8E",
@@ -4086,7 +4104,7 @@
                         .catch(err("rsassa-pkcs1", "importKey", "jwk-priv"));
 
                         //spki
-                        window.crypto.subtle.importKey("spki", new Uint8Array([
+                        window_crypto_subtle.importKey("spki", new Uint8Array([
                             48,129,159,48,13,6,9,42,134,72,134,247,13,1,1,1,5,0,3,
                             129,141,0,48,129,137,2,129,129,0,182,93,35,213,252,204,
                             20,103,91,238,105,199,53,114,24,221,114,210,137,173,88,
@@ -4102,7 +4120,7 @@
                         .catch(err("rsassa-pkcs1", "importKey", "spki-pub"));
 
                         //pkcs8
-                        window.crypto.subtle.importKey("pkcs8", new Uint8Array([
+                        window_crypto_subtle.importKey("pkcs8", new Uint8Array([
                             48,130,2,118,2,1,0,48,13,6,9,42,134,72,134,247,13,1,1,1,5,0,4,130,2,96,48,130,2,92,2,1,0,2,129,
                             129,0,217,78,147,218,221,152,10,66,75,127,242,108,182,142,157,44,93,58,176,193,135,103,216,179,
                             69,72,38,115,144,244,12,139,0,245,48,115,204,234,158,193,231,127,178,240,244,203,35,229,203,245,
@@ -4134,25 +4152,25 @@
                 <td class="exportKey unsafe">
                     <script>
                         //exportKey
-                        window.crypto.subtle.generateKey(RSASSA, true, ["sign", "verify"])
+                        window_crypto_subtle.generateKey(RSASSA, true, ["sign", "verify"])
                         .then(function(key){
 
                             //jwk
-                            window.crypto.subtle.exportKey("jwk", key.publicKey)
+                            window_crypto_subtle.exportKey("jwk", key.publicKey)
                             .then(ok("rsassa-pkcs1", "exportKey", "jwk-pub"))
                             .catch(err("rsassa-pkcs1", "exportKey", "jwk-pub"));
 
-                            window.crypto.subtle.exportKey("jwk", key.privateKey)
+                            window_crypto_subtle.exportKey("jwk", key.privateKey)
                             .then(ok("rsassa-pkcs1", "exportKey", "jwk-priv"))
                             .catch(err("rsassa-pkcs1", "exportKey", "jwk-priv"));
 
                             //spki
-                            window.crypto.subtle.exportKey("spki", key.publicKey)
+                            window_crypto_subtle.exportKey("spki", key.publicKey)
                             .then(ok("rsassa-pkcs1", "exportKey", "spki-pub"))
                             .catch(err("rsassa-pkcs1", "exportKey", "spki-pub"));
 
                             //pkcs8
-                            window.crypto.subtle.exportKey("pkcs8", key.privateKey)
+                            window_crypto_subtle.exportKey("pkcs8", key.privateKey)
                             .then(ok("rsassa-pkcs1", "exportKey", "pkcs8-priv"))
                             .catch(err("rsassa-pkcs1", "exportKey", "pkcs8-priv"));
 
@@ -4170,18 +4188,6 @@
             ###   RSA-PSS   ###
             ###################
             -->
-            <script>
-                //Base algorithm for testing
-                window.RSAPSS = {
-                    name: "RSA-PSS",
-                    //NOTE: THIS IS A SMALL MODULUS FOR TESTING ONLY
-                    //DO NOT USE IT FOR REAL! USE AT LEAST 2048
-                    modulusLength: 1024,
-                    publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
-                    saltLength: 8,
-                    hash: {name: "SHA-256"},
-                }
-            </script>
             <tr id="rsa-pss">
                 <td class="algname"><a href="https://github.com/diafygi/webcrypto-examples/#rsa-pss">RSA-PSS</a></td>
                 <td class="encrypt disabled"></td>
@@ -4189,9 +4195,9 @@
                 <td class="sign unsafe">
                     <script>
                         //sign
-                        window.crypto.subtle.generateKey(RSAPSS, false, ["sign"])
+                        window_crypto_subtle.generateKey(RSAPSS, false, ["sign"])
                         .then(function(key){
-                            return window.crypto.subtle.sign(RSAPSS, key.privateKey, TESTBYTES);
+                            return window_crypto_subtle.sign(RSAPSS, key.privateKey, TESTBYTES);
                         })
                         .then(ok("rsa-pss", "sign", "Yes"))
                         .catch(err("rsa-pss", "sign", "No"));
@@ -4200,11 +4206,11 @@
                 <td class="verify unsafe">
                     <script>
                         //verify
-                        window.crypto.subtle.generateKey(RSAPSS, false, ["sign", "verify"])
+                        window_crypto_subtle.generateKey(RSAPSS, false, ["sign", "verify"])
                         .then(function(key){
-                            window.crypto.subtle.sign(RSAPSS, key.privateKey, TESTBYTES)
+                            window_crypto_subtle.sign(RSAPSS, key.privateKey, TESTBYTES)
                             .then(function(sig){
-                                return window.crypto.subtle.verify(RSAPSS, key.publicKey, sig, TESTBYTES);
+                                return window_crypto_subtle.verify(RSAPSS, key.publicKey, sig, TESTBYTES);
                             })
                             .then(ok("rsa-pss", "verify", "Yes"))
                             .catch(err("rsa-pss", "verify", "No"));
@@ -4222,7 +4228,7 @@
                             evt.target.style.display = "none";
 
                             //1024 bits
-                            window.crypto.subtle.generateKey({
+                            window_crypto_subtle.generateKey({
                                 name: "RSA-PSS",
                                 modulusLength: 1024,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -4233,7 +4239,7 @@
                             .catch(err("rsa-pss", "generateKey", "1024 bits"));
 
                             //2048 bits
-                            window.crypto.subtle.generateKey({
+                            window_crypto_subtle.generateKey({
                                 name: "RSA-PSS",
                                 modulusLength: 2048,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -4244,7 +4250,7 @@
                             .catch(err("rsa-pss", "generateKey", "2048 bits"));
 
                             //4096 bits
-                            window.crypto.subtle.generateKey({
+                            window_crypto_subtle.generateKey({
                                 name: "RSA-PSS",
                                 modulusLength: 4096,
                                 publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
@@ -4264,7 +4270,7 @@
                         //importKey
 
                         //jwk
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "RSA",
                             e: "AQAB",
                             n: "vGO3eU16ag9zRkJ4AK8ZUZrjbtp5xWK0LyFMNT8933evJoHeczexMUzSiXaLrEFSyQZortk81zJH3y41MBO_UFDO_X0crAquNrkjZDrf9Scc5-MdxlWU2Jl7Gc4Z18AC9aNibWVmXhgvHYkEoFdLCFG-2Sq-qIyW4KFkjan05IE",
@@ -4274,7 +4280,7 @@
                         .then(ok("rsa-pss", "importKey", "jwk-pub"))
                         .catch(err("rsa-pss", "importKey", "jwk-pub"));
 
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "RSA",
                             e: "AQAB",
                             d: "n_dIVw9MD_04lANi5KnKJPoRfxKy7cGHYLG0hU5DGpsFNfx2yH0Uz9j8uU7ZARai1iHECBxcxhpi3wbckQtjmbkCUKvs4G0gKLT9UuNHcCbh0WfvadfPPec52n4z6s4zwisbgWCNbT2L-SyHt1yuFmLAYXkg0swk3y5Bt_ilA8E",
@@ -4291,7 +4297,7 @@
                         .catch(err("rsa-pss", "importKey", "jwk-priv"));
 
                         //spki
-                        window.crypto.subtle.importKey("spki", new Uint8Array([
+                        window_crypto_subtle.importKey("spki", new Uint8Array([
                             48,129,159,48,13,6,9,42,134,72,134,247,13,1,1,1,5,0,3,129,141,0,
                             48,129,137,2,129,129,0,180,31,227,200,37,227,65,238,23,91,226,130,
                             51,32,165,245,1,24,244,5,184,42,181,155,23,142,249,220,222,131,
@@ -4306,7 +4312,7 @@
                         .catch(err("rsa-pss", "importKey", "spki-pub"));
 
                         //pkcs8
-                        window.crypto.subtle.importKey("pkcs8", new Uint8Array([
+                        window_crypto_subtle.importKey("pkcs8", new Uint8Array([
                             48,130,2,119,2,1,0,48,13,6,9,42,134,72,134,247,13,1,1,1,5,0,4,130,2,97,48,130,2,93,2,1,0,
                             2,129,129,0,180,31,227,200,37,227,65,238,23,91,226,130,51,32,165,245,1,24,244,5,184,42,181,
                             155,23,142,249,220,222,131,175,54,117,135,64,232,120,90,160,221,18,31,200,41,23,174,18,172,
@@ -4340,25 +4346,25 @@
                 <td class="exportKey unsafe">
                     <script>
                         //exportKey
-                        window.crypto.subtle.generateKey(RSAPSS, true, ["sign", "verify"])
+                        window_crypto_subtle.generateKey(RSAPSS, true, ["sign", "verify"])
                         .then(function(key){
 
                             //jwk
-                            window.crypto.subtle.exportKey("jwk", key.publicKey)
+                            window_crypto_subtle.exportKey("jwk", key.publicKey)
                             .then(ok("rsa-pss", "exportKey", "jwk-pub"))
                             .catch(err("rsa-pss", "exportKey", "jwk-pub"));
 
-                            window.crypto.subtle.exportKey("jwk", key.privateKey)
+                            window_crypto_subtle.exportKey("jwk", key.privateKey)
                             .then(ok("rsa-pss", "exportKey", "jwk-priv"))
                             .catch(err("rsa-pss", "exportKey", "jwk-priv"));
 
                             //spki
-                            window.crypto.subtle.exportKey("spki", key.publicKey)
+                            window_crypto_subtle.exportKey("spki", key.publicKey)
                             .then(ok("rsa-pss", "exportKey", "spki-pub"))
                             .catch(err("rsa-pss", "exportKey", "spki-pub"));
 
                             //pkcs8
-                            window.crypto.subtle.exportKey("pkcs8", key.privateKey)
+                            window_crypto_subtle.exportKey("pkcs8", key.privateKey)
                             .then(ok("rsa-pss", "exportKey", "pkcs8-priv"))
                             .catch(err("rsa-pss", "exportKey", "pkcs8-priv"));
 
@@ -4376,13 +4382,6 @@
             ###   AES-CMAC   ###
             ####################
             -->
-            <script>
-                //Base algorithm for testing
-                window.AESCMAC = {
-                    name: "AES-CMAC",
-                    length: 256,
-                }
-            </script>
             <tr id="aes-cmac">
                 <td class="algname"><a href="https://github.com/diafygi/webcrypto-examples/#aes-cmac">AES-CMAC</a></td>
                 <td class="encrypt disabled"></td>
@@ -4390,9 +4389,9 @@
                 <td class="sign unsafe">
                     <script>
                         //sign
-                        window.crypto.subtle.generateKey(AESCMAC, false, ["sign"])
+                        window_crypto_subtle.generateKey(AESCMAC, false, ["sign"])
                         .then(function(key){
-                            return window.crypto.subtle.sign({name: "AES-CMAC", lenth: 256}, key, TESTBYTES);
+                            return window_crypto_subtle.sign({name: "AES-CMAC", lenth: 256}, key, TESTBYTES);
                         })
                         .then(ok("aes-cmac", "sign", "Yes"))
                         .catch(err("aes-cmac", "sign", "No"));
@@ -4401,11 +4400,11 @@
                 <td class="verify unsafe">
                     <script>
                         //verify
-                        window.crypto.subtle.generateKey(AESCMAC, false, ["sign", "verify"])
+                        window_crypto_subtle.generateKey(AESCMAC, false, ["sign", "verify"])
                         .then(function(key){
-                            window.crypto.subtle.sign({name: "AES-CMAC", lenth: 256}, key, TESTBYTES)
+                            window_crypto_subtle.sign({name: "AES-CMAC", lenth: 256}, key, TESTBYTES)
                             .then(function(sig){
-                                return window.crypto.subtle.verify({name: "AES-CMAC", lenth: 256}, key, sig, TESTBYTES);
+                                return window_crypto_subtle.verify({name: "AES-CMAC", lenth: 256}, key, sig, TESTBYTES);
                             })
                             .then(ok("aes-cmac", "verify", "Yes"))
                             .catch(err("aes-cmac", "verify", "No"));
@@ -4419,17 +4418,17 @@
                         //generateKey
 
                         //128 bits
-                        window.crypto.subtle.generateKey({name: "AES-CMAC", length: 128}, false, ["sign", "verify"])
+                        window_crypto_subtle.generateKey({name: "AES-CMAC", length: 128}, false, ["sign", "verify"])
                         .then(ok("aes-cmac", "generateKey", "128 bits"))
                         .catch(err("aes-cmac", "generateKey", "128 bits"));
 
                         //192 bits
-                        window.crypto.subtle.generateKey({name: "AES-CMAC", length: 192}, false, ["sign", "verify"])
+                        window_crypto_subtle.generateKey({name: "AES-CMAC", length: 192}, false, ["sign", "verify"])
                         .then(ok("aes-cmac", "generateKey", "192 bits"))
                         .catch(err("aes-cmac", "generateKey", "192 bits"));
 
                         //256 bits
-                        window.crypto.subtle.generateKey({name: "AES-CMAC", length: 256}, false, ["sign", "verify"])
+                        window_crypto_subtle.generateKey({name: "AES-CMAC", length: 256}, false, ["sign", "verify"])
                         .then(ok("aes-cmac", "generateKey", "256 bits"))
                         .catch(err("aes-cmac", "generateKey", "256 bits"));
                     </script>
@@ -4441,7 +4440,7 @@
                         //importKey
 
                         //jwk
-                        window.crypto.subtle.importKey("jwk", {
+                        window_crypto_subtle.importKey("jwk", {
                             kty: "oct",
                             k: "Y0zt37HgOx-BY7SQjYVmrqhPkO44Ii2Jcb9yydUDPfE",
                             alg: "A256CMAC",
@@ -4451,7 +4450,7 @@
                         .catch(err("aes-cmac", "importKey", "jwk-key"));
 
                         //raw
-                        window.crypto.subtle.importKey("raw", new Uint8Array([
+                        window_crypto_subtle.importKey("raw", new Uint8Array([
                             122,94,39,230,46,23,151,80,131,230,3,101,80,234,143,9,251,
                             152,229,228,89,222,31,135,214,104,55,68,67,59,5,51
                         ]), AESCMAC, false, ["sign", "verify"])
@@ -4462,16 +4461,16 @@
                 <td class="exportKey unsafe">
                     <script>
                         //exportKey
-                        window.crypto.subtle.generateKey(AESCMAC, true, ["sign", "verify"])
+                        window_crypto_subtle.generateKey(AESCMAC, true, ["sign", "verify"])
                         .then(function(key){
 
                             //jwk
-                            window.crypto.subtle.exportKey("jwk", key)
+                            window_crypto_subtle.exportKey("jwk", key)
                             .then(ok("aes-cmac", "exportKey", "jwk-key"))
                             .catch(err("aes-cmac", "exportKey", "jwk-key"));
 
                             //raw
-                            window.crypto.subtle.exportKey("raw", key)
+                            window_crypto_subtle.exportKey("raw", key)
                             .then(ok("aes-cmac", "exportKey", "raw-key"))
                             .catch(err("aes-cmac", "exportKey", "raw-key"));
 
@@ -4498,7 +4497,7 @@
                 <td class="digest unsafe">
                     <script>
                         //digest
-                        window.crypto.subtle.digest({name: "SHA-1"}, TESTBYTES)
+                        window_crypto_subtle.digest({name: "SHA-1"}, TESTBYTES)
                         .then(ok("sha-1", "digest", "Yes"))
                         .catch(err("sha-1", "digest", "No"));
                     </script>
@@ -4518,27 +4517,6 @@
             ###   DH   ###
             ##############
             -->
-            <script>
-                //Base algorithm for testing
-                window.DH = {
-                    name: "DH",
-                    //NOTE: THIS IS A SMALL PRIME FOR TESTING ONLY
-                    //DO NOT USE IT FOR REAL!
-                    //See http://datatracker.ietf.org/doc/rfc3526/ for better primes
-                    prime: new Uint8Array([
-                        255,255,255,255,255,255,255,255,201,15,218,162,33,104,194,52,196,198,98,139,
-                        128,220,28,209,41,2,78,8,138,103,204,116,2,11,190,166,59,19,155,34,81,74,8,
-                        121,142,52,4,221,239,149,25,179,205,58,67,27,48,43,10,109,242,95,20,55,79,225,
-                        53,109,109,81,194,69,228,133,181,118,98,94,126,198,244,76,66,233,166,55,237,
-                        107,11,255,92,182,244,6,183,237,238,56,107,251,90,137,159,165,174,159,36,17,
-                        124,75,31,230,73,40,102,81,236,228,91,61,194,0,124,184,161,99,191,5,152,218,
-                        72,54,28,85,211,154,105,22,63,168,253,36,207,95,131,101,93,35,220,163,173,
-                        150,28,98,243,86,32,133,82,187,158,213,41,7,112,150,150,109,103,12,53,78,74,
-                        188,152,4,241,116,108,8,202,35,115,39,255,255,255,255,255,255,255,255
-                    ]),
-                    generator: new Uint8Array([2]),
-                }
-            </script>
             <tr id="dh">
                 <td class="algname"><a href="https://github.com/diafygi/webcrypto-examples/#dh">DH</a></td>
                 <td class="encrypt disabled"></td>
@@ -4549,7 +4527,7 @@
                 <td class="generateKey unsafe">
                     <script>
                         //generateKey
-                        window.crypto.subtle.generateKey(DH, false, ["deriveBits", "deriveKey"])
+                        window_crypto_subtle.generateKey(DH, false, ["deriveBits", "deriveKey"])
                         .then(ok("dh", "generateKey", "Yes"))
                         .catch(err("dh", "generateKey", "No"));
                     </script>
@@ -4557,12 +4535,12 @@
                 <td class="deriveKey unsafe">
                     <script>
                         //deriveKey
-                        window.crypto.subtle.generateKey(DH, false, ["deriveKey"])
+                        window_crypto_subtle.generateKey(DH, false, ["deriveKey"])
                         .then(function(key1){
-                            window.crypto.subtle.generateKey(DH, false, ["deriveKey"])
+                            window_crypto_subtle.generateKey(DH, false, ["deriveKey"])
                             .then(function(key2){
 
-                                window.crypto.subtle.deriveKey({
+                                window_crypto_subtle.deriveKey({
                                     "name": "DH",
                                     //NOTE: THIS IS A SMALL PRIME FOR TESTING ONLY
                                     //DO NOT USE IT FOR REAL!
@@ -4593,12 +4571,12 @@
                 <td class="deriveBits unsafe">
                     <script>
                         //deriveBits
-                        window.crypto.subtle.generateKey(DH, false, ["deriveBits"])
+                        window_crypto_subtle.generateKey(DH, false, ["deriveBits"])
                         .then(function(key1){
-                            window.crypto.subtle.generateKey(DH, false, ["deriveBits"])
+                            window_crypto_subtle.generateKey(DH, false, ["deriveBits"])
                             .then(function(key2){
 
-                                window.crypto.subtle.deriveBits({
+                                window_crypto_subtle.deriveBits({
                                     "name": "DH",
                                     //NOTE: THIS IS A SMALL PRIME FOR TESTING ONLY
                                     //DO NOT USE IT FOR REAL!
@@ -4631,7 +4609,7 @@
                         //importKey
 
                         //raw
-                        window.crypto.subtle.importKey("raw", new Uint8Array([
+                        window_crypto_subtle.importKey("raw", new Uint8Array([
                             203,25,0,203,43,75,46,159,217,37,185,181,25,220,71,187,112,195,251,233,152,56,206,
                             93,18,96,87,132,17,113,166,110,123,190,194,168,100,147,21,174,131,80,8,247,125,35,
                             210,70,103,141,152,173,99,74,34,132,92,134,216,55,171,186,89,167,189,217,164,119,
@@ -4646,7 +4624,7 @@
                         .catch(err("dh", "importKey", "raw-pub"));
 
                         //spki
-                        window.crypto.subtle.importKey("spki", new Uint8Array([
+                        window_crypto_subtle.importKey("spki", new Uint8Array([
                             48,130,1,160,48,129,214,6,9,42,134,72,134,247,13,1,3,1,48,129,200,2,129,192,
                             255,255,255,255,255,255,255,255,201,15,218,162,33,104,194,52,196,198,98,139,
                             128,220,28,209,41,2,78,8,138,103,204,116,2,11,190,166,59,19,155,34,81,74,8,
@@ -4671,7 +4649,7 @@
                         .catch(err("dh", "importKey", "spki-pub"));
 
                         //pkcs8
-                        window.crypto.subtle.importKey("pkcs8", null, DH, false, ["deriveBits", "deriveKey"])
+                        window_crypto_subtle.importKey("pkcs8", null, DH, false, ["deriveBits", "deriveKey"])
                         .then(ok("dh", "importKey", "pkcs8-priv"))
                         .catch(err("dh", "importKey", "pkcs8-priv*"));
                     </script>
@@ -4679,25 +4657,25 @@
                 <td class="exportKey unsafe">
                     <script>
                         //exportKey
-                        window.crypto.subtle.generateKey(DH, true, ["deriveBits", "deriveKey"])
+                        window_crypto_subtle.generateKey(DH, true, ["deriveBits", "deriveKey"])
                         .then(function(key){
 
                             //raw
-                            window.crypto.subtle.exportKey("raw", key.publicKey)
+                            window_crypto_subtle.exportKey("raw", key.publicKey)
                             .then(ok("dh", "exportKey", "raw-pub"))
                             .catch(err("dh", "exportKey", "raw-pub"));
 
-                            window.crypto.subtle.exportKey("raw", key.privateKey)
+                            window_crypto_subtle.exportKey("raw", key.privateKey)
                             .then(ok("dh", "exportKey", "raw-priv"))
                             .catch(err("dh", "exportKey", "raw-priv"));
 
                             //spki
-                            window.crypto.subtle.exportKey("spki", key.publicKey)
+                            window_crypto_subtle.exportKey("spki", key.publicKey)
                             .then(ok("dh", "exportKey", "spki-pub"))
                             .catch(err("dh", "exportKey", "spki-pub"));
 
                             //pkcs8
-                            window.crypto.subtle.exportKey("pkcs8", key.privateKey)
+                            window_crypto_subtle.exportKey("pkcs8", key.privateKey)
                             .then(ok("dh", "exportKey", "pkcs8-priv"))
                             .catch(err("dh", "exportKey", "pkcs8-priv"));
 
@@ -4727,10 +4705,10 @@
                     <script>
                         //deriveKey
                         var keydata = window.crypto.getRandomValues(new Uint8Array(16));
-                        window.crypto.subtle.importKey("raw", keydata, {name: "CONCAT"}, false, ["deriveBits", "deriveKey"])
+                        window_crypto_subtle.importKey("raw", keydata, {name: "CONCAT"}, false, ["deriveBits", "deriveKey"])
                         .then(function(key){
 
-                            window.crypto.subtle.deriveBits({
+                            window_crypto_subtle.deriveBits({
                                 name: "CONCAT",
                                 algorithmId: "?????",
                                 partyUInfo: "?????",
@@ -4750,10 +4728,10 @@
                     <script>
                         //deriveBits
                         var keydata = window.crypto.getRandomValues(new Uint8Array(16));
-                        window.crypto.subtle.importKey("raw", keydata, {name: "CONCAT"}, false, ["deriveBits", "deriveKey"])
+                        window_crypto_subtle.importKey("raw", keydata, {name: "CONCAT"}, false, ["deriveBits", "deriveKey"])
                         .then(function(key){
 
-                            window.crypto.subtle.deriveBits({
+                            window_crypto_subtle.deriveBits({
                                 name: "CONCAT",
                                 algorithmId: "?????",
                                 partyUInfo: "?????",
@@ -4775,7 +4753,7 @@
 
                         //raw
                         var keydata = window.crypto.getRandomValues(new Uint8Array(16));
-                        window.crypto.subtle.importKey("raw", keydata, {name: "CONCAT"}, false, ["deriveBits", "deriveKey"])
+                        window_crypto_subtle.importKey("raw", keydata, {name: "CONCAT"}, false, ["deriveBits", "deriveKey"])
                         .then(ok("concatkdf", "importKey", "raw"))
                         .catch(err("concatkdf", "importKey", "raw*"));
                     </script>
@@ -4803,10 +4781,10 @@
                     <script>
                         //deriveKey
                         var keydata = window.crypto.getRandomValues(new Uint8Array(16));
-                        window.crypto.subtle.importKey("raw", keydata, {name: "HKDF-CTR"}, false, ["deriveBits", "deriveKey"])
+                        window_crypto_subtle.importKey("raw", keydata, {name: "HKDF-CTR"}, false, ["deriveBits", "deriveKey"])
                         .then(function(key){
 
-                            window.crypto.subtle.deriveBits({
+                            window_crypto_subtle.deriveBits({
                                 name: "HKDF-CTR",
                                 label: "?????",
                                 context: "?????",
@@ -4823,10 +4801,10 @@
                     <script>
                         //deriveBits
                         var keydata = window.crypto.getRandomValues(new Uint8Array(16));
-                        window.crypto.subtle.importKey("raw", keydata, {name: "HKDF-CTR"}, false, ["deriveBits", "deriveKey"])
+                        window_crypto_subtle.importKey("raw", keydata, {name: "HKDF-CTR"}, false, ["deriveBits", "deriveKey"])
                         .then(function(key){
 
-                            window.crypto.subtle.deriveBits({
+                            window_crypto_subtle.deriveBits({
                                 name: "HKDF-CTR",
                                 label: "?????",
                                 context: "?????",
@@ -4845,7 +4823,7 @@
 
                         //raw
                         var keydata = window.crypto.getRandomValues(new Uint8Array(16));
-                        window.crypto.subtle.importKey("raw", keydata, {name: "HKDF-CTR"}, false, ["deriveBits", "deriveKey"])
+                        window_crypto_subtle.importKey("raw", keydata, {name: "HKDF-CTR"}, false, ["deriveBits", "deriveKey"])
                         .then(ok("hkdf-ctr", "importKey", "raw"))
                         .catch(err("hkdf-ctr", "importKey", "raw*"));
                     </script>


### PR DESCRIPTION
See commit description (below) for details.

Here is a live sample of the proposed changes:
https://webcryptoexamples.azurewebsites.net/

Here is what Safari on iOS 9 looks like today without the change:
https://webcryptoexamples.azurewebsites.net/iOS9-Safari-Before.png

And here's what it looks like with the proposed change:
https://webcryptoexamples.azurewebsites.net/iOS9-Safari-After.png

Note, for example, that importKey/AES-KW/raw-key is identified as being supported (vs. blank).

Tested on:
- iOS 9/Safari
- Android/Chrome
- Windows/Chrome
- Windows/Firefox
- Windows/Edge
- Windows/IE 11

Improvements seen on:
- iOS 9/Safari
- Windows/Firefox
## 

When an exception is thrown by the synchronous part of a Promise-returning function, that exception is (by design) not handled by any catch clauses associated with the call. Because of this, synchronous exceptions in cryptographic calls by the sample page can bubble up as script errors and cancel execution of the current and all remaining calls in a script block. As a result, compatibility information on some platforms (for example, Safari on iOS 9) is incomplete.

This change improves things by wrapping all calls to cryptographic functions in a Promise context so the existing catch clause executes and displays information about the relevant failure. Subsequent tests in the same script block are now able to run and display their own pass/fail information.

To minimize churn, this change wraps all cryptographic functions in a Promise context so each of the existing calls are (relatively) unchanged. (Platforms that do not support Promises do not benefit, but are no worse off.) An alternate implementation would be to introduce a Promise wrapper around each of the initial calls in a chain, but that causes more significant changes to the code and obfuscates the intent somewhat. Another alternate implementation would be to wrap each chain in a try/catch block, but that seems even more impactful/confusing. Configuration for each of the algorithms was moved to the top of the file because execution is now more asynchronous and it is possible for a configuration to be used before being initialized.
