### PR TITLE
Change HKDF-CTR to HKDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ wrote examples and made a live table with them. Pull requests welcome!
 [deriveKey](#concat---derivekey) |
 [deriveBits](#concat---derivebits)
 
-19. [HKDF-CTR](#hkdf-ctr)
-  * [importKey](#hkdf-ctr---importkey) |
-[deriveKey](#hkdf-ctr---derivekey) |
-[deriveBits](#hkdf-ctr---derivebits)
+19. [HKDF](#hkdf)
+  * [importKey](#hkdf---importkey) |
+[deriveKey](#hkdf---derivekey) |
+[deriveBits](#hkdf---derivebits)
 
 20. [PBKDF2](#pbkdf2)
   * [generateKey](#pbkdf2---generatekey) |
@@ -1870,14 +1870,14 @@ window.crypto.subtle.deriveBits(
 });
 ```
 
-## HKDF-CTR
-#### HKDF-CTR - importKey
+## HKDF
+#### HKDF - importKey
 ```javascript
 window.crypto.subtle.importKey(
     "raw", //only "raw" is allowed
     keydata, //your raw key data as an ArrayBuffer
     {
-        name: "HKDF-CTR",
+        name: "HKDF",
     },
     false, //whether the key is extractable (i.e. can be used in exportKey)
     ["deriveKey", "deriveBits"] //can be any combination of "deriveKey" and "deriveBits"
@@ -1890,13 +1890,13 @@ window.crypto.subtle.importKey(
     console.error(err);
 });
 ```
-#### HKDF-CTR - deriveKey
+#### HKDF - deriveKey
 ```javascript
 window.crypto.subtle.deriveKey(
     {
-        "name": "HKDF-CTR",
-        label: ArrayBuffer, //?????? I don't know what this should be
-        context: ArrayBuffer, //?????? I don't know what this should be
+        "name": "HKDF",
+        salt: ArrayBuffer, // one time use salt
+        info: ArrayBuffer, // extra authenticated data
         hash: {name: "SHA-1"}, //can be "SHA-1", "SHA-256", "SHA-384", or "SHA-512"
     },
     key, //your key from importKey
@@ -1916,13 +1916,13 @@ window.crypto.subtle.deriveKey(
     console.error(err);
 });
 ```
-#### HKDF-CTR - deriveBits
+#### HKDF - deriveBits
 ```javascript
 window.crypto.subtle.deriveBits(
     {
-        "name": "HKDF-CTR",
-        label: ArrayBuffer, //?????? I don't know what this should be
-        context: ArrayBuffer, //?????? I don't know what this should be
+        "name": "HKDF",
+        salt: ArrayBuffer, // one time use salt
+        info: ArrayBuffer, // extra authenticated data
         hash: {name: "SHA-1"}, //can be "SHA-1", "SHA-256", "SHA-384", or "SHA-512"
     },
     key, //your key importKey

--- a/index.html
+++ b/index.html
@@ -4789,11 +4789,11 @@
 
             <!--
             ####################
-            ###   HKDF-CTR   ###
+            ###   HKDF   ###
             ####################
             -->
-            <tr id="hkdf-ctr">
-                <td class="algname"><a href="https://github.com/diafygi/webcrypto-examples/#hkdf-ctr">HKDF-CTR</a></td>
+            <tr id="hkdf">
+                <td class="algname"><a href="https://github.com/diafygi/webcrypto-examples/#hkdf">HKDF</a></td>
                 <td class="encrypt disabled"></td>
                 <td class="decrypt disabled"></td>
                 <td class="sign disabled"></td>
@@ -4804,40 +4804,40 @@
                     <script>
                         //deriveKey
                         var keydata = window.crypto.getRandomValues(new Uint8Array(16));
-                        window.crypto.subtle.importKey("raw", keydata, {name: "HKDF-CTR"}, false, ["deriveBits", "deriveKey"])
+                        window.crypto.subtle.importKey("raw", keydata, {name: "HKDF"}, false, ["deriveBits", "deriveKey"])
                         .then(function(key){
 
                             window.crypto.subtle.deriveBits({
-                                name: "HKDF-CTR",
-                                label: "?????",
-                                context: "?????",
+                                name: "HKDF",
+                                salt: window.crypto.getRandomValues(new Uint8Array(16)),
+                                info: window.crypto.getRandomValues(new Uint8Array(16)),
                                 hash: {name: "SHA-1"},
-                            }, "?????", AESCBC, false, ["encrypt", "decrypt"])
-                            .then(ok("hkdf-ctr", "deriveKey", "Yes"))
-                            .catch(err("hkdf-ctr", "deriveKey", "No"));
+                            }, key, AESCBC, false, ["encrypt", "decrypt"])
+                            .then(ok("hkdf", "deriveKey", "Yes"))
+                            .catch(err("hkdf", "deriveKey", "No"));
 
                         })
-                        .catch(err("hkdf-ctr", "deriveKey", "N/A"));
+                        .catch(err("hkdf", "deriveKey", "N/A"));
                     </script>
                 </td>
                 <td class="deriveBits unsafe">
                     <script>
                         //deriveBits
                         var keydata = window.crypto.getRandomValues(new Uint8Array(16));
-                        window.crypto.subtle.importKey("raw", keydata, {name: "HKDF-CTR"}, false, ["deriveBits", "deriveKey"])
+                        window.crypto.subtle.importKey("raw", keydata, {name: "HKDF"}, false, ["deriveBits", "deriveKey"])
                         .then(function(key){
 
                             window.crypto.subtle.deriveBits({
-                                name: "HKDF-CTR",
-                                label: "?????",
-                                context: "?????",
+                                name: "HKDF",
+                                salt: window.crypto.getRandomValues(new Uint8Array(16)),
+                                info: window.crypto.getRandomValues(new Uint8Array(16)),
                                 hash: {name: "SHA-1"},
-                            }, "?????", 128)
-                            .then(ok("hkdf-ctr", "deriveBits", "Yes"))
-                            .catch(err("hkdf-ctr", "deriveBits", "No"));
+                            }, key, 128)
+                            .then(ok("hkdf", "deriveBits", "Yes"))
+                            .catch(err("hkdf", "deriveBits", "No"));
 
                         })
-                        .catch(err("hkdf-ctr", "deriveBits", "N/A"));
+                        .catch(err("hkdf", "deriveBits", "N/A"));
                     </script>
                 </td>
                 <td class="importKey unsafe">
@@ -4846,9 +4846,9 @@
 
                         //raw
                         var keydata = window.crypto.getRandomValues(new Uint8Array(16));
-                        window.crypto.subtle.importKey("raw", keydata, {name: "HKDF-CTR"}, false, ["deriveBits", "deriveKey"])
-                        .then(ok("hkdf-ctr", "importKey", "raw"))
-                        .catch(err("hkdf-ctr", "importKey", "raw*"));
+                        window.crypto.subtle.importKey("raw", keydata, {name: "HKDF"}, false, ["deriveBits", "deriveKey"])
+                        .then(ok("hkdf", "importKey", "raw"))
+                        .catch(err("hkdf", "importKey", "raw*"));
                     </script>
                 </td>
                 <td class="exportKey disabled"></td>


### PR DESCRIPTION
**Summary**
This PR removes the HKDF-CTR algorithm, which was removed from webcrypto, in favor of [HKDF](https://en.wikipedia.org/wiki/HKDF).

There are two changes: one for the documentations in `README.md` and the other for the live table tester table.

**Test Plan**
This was tested against Chrome 67.0.3396.79. All implementations pass correctly.
![chrome](https://user-images.githubusercontent.com/205628/41199529-991f8d02-6c48-11e8-8be6-8019267b4768.png)

This was also tested against Firefox 60, however it seems to be throwing a `An invalid or illegal string was specified` exception on `deriveKey`, while `deriveBits` succeeds. I am unsure if the issue is my implementation or an issue with Firefox.

![screenshot from 2018-06-10 00-54-14](https://user-images.githubusercontent.com/205628/41199545-d0a20106-6c48-11e8-9a80-133d3634d2ed.png)

Fixes #46
