### PR TITLE
Add doc for 'label' and 'context' params in HKDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1895,8 +1895,8 @@ window.crypto.subtle.importKey(
 window.crypto.subtle.deriveKey(
     {
         "name": "HKDF-CTR",
-        label: ArrayBuffer, //?????? I don't know what this should be
-        context: ArrayBuffer, //?????? I don't know what this should be
+        label: ArrayBuffer, //named 'salt' in the spec; an optional non-secret random value for the extract phase
+        context: ArrayBuffer, //optional application specific info (e.g. 'aes-key' or 'hmac-key') so you can derive different keys for the same input keying material
         hash: {name: "SHA-1"}, //can be "SHA-1", "SHA-256", "SHA-384", or "SHA-512"
     },
     key, //your key from importKey
@@ -1921,8 +1921,8 @@ window.crypto.subtle.deriveKey(
 window.crypto.subtle.deriveBits(
     {
         "name": "HKDF-CTR",
-        label: ArrayBuffer, //?????? I don't know what this should be
-        context: ArrayBuffer, //?????? I don't know what this should be
+        label: ArrayBuffer, //named 'salt' in the spec; an optional non-secret random value for the extract phase
+        context: ArrayBuffer, //optional application specific info (e.g. 'aes-key' or 'hmac-key') so you can derive different keys for the same input keying material
         hash: {name: "SHA-1"}, //can be "SHA-1", "SHA-256", "SHA-384", or "SHA-512"
     },
     key, //your key importKey


### PR DESCRIPTION
These are according to the HKDF spec: https://tools.ietf.org/html/rfc5869

There is a extract and a expand phase. The `salt` (aka `label`) is used in 
the extract phase:

    HKDF-Extract(salt, IKM) -> PRK
    salt     optional salt value (a non-secret random value);
             if not provided, it is set to a string of HashLen zeros.

and the `info` (aka `context`) is used in the expand phase:

    HKDF-Expand(PRK, info, L) -> OKM
    info     optional context and application specific information
             (can be a zero-length string)